### PR TITLE
fix: 빌드 오류 해결

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -13,6 +13,12 @@
     "react/no-unescaped-entities": 0,
     "@next/next/no-page-custom-font": "off",
     "tailwindcss/no-custom-classname": "off",
-    "tailwindcss/classnames-order": "off"
+    "tailwindcss/classnames-order": "off",
+    "prettier/prettier": [
+      "error",
+      {
+        "endOfLine": "auto"
+      }
+    ]
   }
 }

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,3 +1,4 @@
 {
+  "endOfLine": "auto",
   "plugins": ["prettier-plugin-tailwindcss"]
 }

--- a/app/(route)/[id]/(_components)/AlimHeader.tsx
+++ b/app/(route)/[id]/(_components)/AlimHeader.tsx
@@ -60,7 +60,7 @@ export function AlimHeader({ matchingId }: AlimHeaderProps) {
         </button>
         <Modal
           isOpen={isModalOpen}
-          onConfirm={() => {
+          handleOnConfirm={() => {
             postMatchingAcceptance(
               {
                 matchingId,
@@ -81,7 +81,7 @@ export function AlimHeader({ matchingId }: AlimHeaderProps) {
               },
             );
           }}
-          onCancel={closeModal}
+          handleOnCancel={closeModal}
           title={JSON.stringify(
             selecteddRowNickName.toString().replaceAll("", ""),
           )}

--- a/app/(route)/[id]/(_components)/TeacherList.tsx
+++ b/app/(route)/[id]/(_components)/TeacherList.tsx
@@ -103,8 +103,8 @@ function TeacherList() {
         isOpen={youtubeModal.isOpen}
         value={youtubeModal.value}
         setValue={youtubeModal.setValue}
-        onSave={youtubeModal.saveValue}
-        onCancel={youtubeModal.closeModal}
+        onSave={youtubeModal.handleSaveValue}
+        onCancel={youtubeModal.handleCloseModal}
         title="선생님 프로필 유튜브 링크 수정"
         placeholder="https://youtube.com/..."
         isTextarea={false}
@@ -115,8 +115,8 @@ function TeacherList() {
         isOpen={remarkModal.isOpen}
         value={remarkModal.value}
         setValue={remarkModal.setValue}
-        onSave={remarkModal.saveValue}
-        onCancel={remarkModal.closeModal}
+        onSave={remarkModal.handleSaveValue}
+        onCancel={remarkModal.handleCloseModal}
         title="간단 비고 수정"
         maxLength={30}
         isTextarea

--- a/app/hooks/custom/useClickoutside.ts
+++ b/app/hooks/custom/useClickoutside.ts
@@ -16,6 +16,6 @@ export function useClickoutside<
     return () => {
       document.removeEventListener("mousedown", listener);
     };
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   }, [ref, callback, deps && [...deps]]);
 }

--- a/app/hooks/custom/useClickoutside.ts
+++ b/app/hooks/custom/useClickoutside.ts
@@ -3,7 +3,7 @@ import { useEffect, MutableRefObject } from "react";
 
 export function useClickoutside<
   T extends MutableRefObject<HTMLDivElement | null>,
->(ref: T, callback?: () => void, deps?: []) {
+>(ref: T, callback?: () => void, deps?: any[]) {
   useEffect(() => {
     const listener = (event: MouseEvent) => {
       if (!ref || !ref.current || ref.current.contains(event.target as Node)) {

--- a/app/hooks/custom/useClickoutside.ts
+++ b/app/hooks/custom/useClickoutside.ts
@@ -1,11 +1,9 @@
 /* eslint-disable promise/prefer-await-to-callbacks */
 import { useEffect, MutableRefObject } from "react";
 
-export function useClickoutside<T extends MutableRefObject<HTMLDivElement>>(
-  ref: T,
-  callback?: () => void,
-  deps?: [],
-) {
+export function useClickoutside<
+  T extends MutableRefObject<HTMLDivElement | null>,
+>(ref: T, callback?: () => void, deps?: []) {
   useEffect(() => {
     const listener = (event: MouseEvent) => {
       if (!ref || !ref.current || ref.current.contains(event.target as Node)) {

--- a/app/hooks/custom/useClickoutside.ts
+++ b/app/hooks/custom/useClickoutside.ts
@@ -3,6 +3,7 @@ import { useEffect, MutableRefObject } from "react";
 
 export function useClickoutside<
   T extends MutableRefObject<HTMLDivElement | null>,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
 >(ref: T, callback?: () => void, deps?: any[]) {
   useEffect(() => {
     const listener = (event: MouseEvent) => {
@@ -15,5 +16,6 @@ export function useClickoutside<
     return () => {
       document.removeEventListener("mousedown", listener);
     };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
   }, [ref, callback, deps && [...deps]]);
 }

--- a/app/hooks/custom/useEditTeacherModal.ts
+++ b/app/hooks/custom/useEditTeacherModal.ts
@@ -24,13 +24,13 @@ export function useEditTeacherModal(
     setValue((teacher[field] as string) ?? "");
   };
 
-  const closeModal = () => {
+  const handleCloseModal = () => {
     setIsOpen(false);
     setTeacherId(null);
     setValue("");
   };
 
-  const saveValue = () => {
+  const handleSaveValue = () => {
     if (teacherId == null || !data) return;
     const currentTeacher = data.find((t) => t.id === teacherId);
     if (!currentTeacher) return;
@@ -40,7 +40,7 @@ export function useEditTeacherModal(
       [field]: value,
     });
 
-    closeModal();
+    handleCloseModal();
   };
 
   return {
@@ -48,7 +48,7 @@ export function useEditTeacherModal(
     value,
     setValue,
     openModal,
-    saveValue,
-    closeModal,
+    handleSaveValue,
+    handleCloseModal,
   };
 }

--- a/app/ui/EditTeacherModal.tsx
+++ b/app/ui/EditTeacherModal.tsx
@@ -31,8 +31,8 @@ export function EditTeacherModal({
       title={title}
       confirmText="저장"
       cancelText="취소"
-      onConfirm={onSave}
-      onCancel={onCancel}
+      handleOnConfirm={onSave}
+      handleOnCancel={onCancel}
       message={
         isTextarea ? (
           <textarea

--- a/app/ui/Modal.tsx
+++ b/app/ui/Modal.tsx
@@ -8,8 +8,8 @@ interface ModalProps {
   message: React.ReactNode;
   confirmText: string;
   cancelText?: string;
-  onConfirm: () => void;
-  onCancel?: () => void;
+  handleOnConfirm: () => void;
+  handleOnCancel?: () => void;
   isOpen: boolean;
 }
 
@@ -21,7 +21,7 @@ export function Modal({
 }: ModalProps) {
   const modalRef = useRef<HTMLDivElement | null>(null);
 
-  useClickoutside(modalRef, rest?.onConfirm, [isOpen]);
+  useClickoutside(modalRef, rest?.handleOnConfirm, [isOpen]);
 
   if (!isOpen) {
     return null;
@@ -35,7 +35,7 @@ export function Modal({
         <div className="flex justify-end">
           {rest.cancelText && (
             <button
-              onClick={rest.onCancel}
+              onClick={rest.handleOnCancel}
               className="mr-2 rounded bg-gray-300 px-4 py-2 text-gray-800 hover:bg-gray-400"
             >
               {rest.cancelText}
@@ -43,7 +43,7 @@ export function Modal({
           )}
 
           <button
-            onClick={rest.onConfirm}
+            onClick={rest.handleOnConfirm}
             className="rounded bg-blue-500 px-4 py-2 text-white hover:bg-blue-600"
           >
             {rest.confirmText}


### PR DESCRIPTION
## 🐈 PR 요약
> PR 내용 한 줄로 요약
- 관련 테크스펙 링크 : 따로없음
- 빌드 오류 fix

## ✨ PR 상세
> PR 상세 내용 개조식으로 작성
- `useClickoutside` 타입 등등 수정 : 원래 `deps?: []`로 되어 있는데 생각해 보니까 이러면 빈 배열밖에 못 들어오는 거니까 `any[]`로 일단 바꿨습니당!
- `eslint` & `prettier` EOL 관련 문제 수정 : 맥이랑 윈도우랑 `endOfLine` 방식이 달라서 prettier, eslint 단에서 맞춰주도록 했습니다!
- 핸들러 함수들 `handleCamelCase`로 작성 : `on어쩌구` 이벤트에 걸리는 함수들은 `handle어쩌구저쩌구` 카멜케이스로 작성해야 한대요! 그래서 다 바꿨습니당

## 🚨 참고사항
> 리뷰어들이 알아야 하거나 알면 좋은 참고사항 작성
- `useClickoutside` 부분은 임시방편으로 해둔 게 많아서 효중님이 한 번 더 봐주셔야 할 것 같아요 👀
- 해당 파일에서 `eslint` 규칙도 2개 정도 무시 처리 해두었습니다! 근데 웬만하면 걷어내고 싶네요!ㅋㅋㅋㅋ
- github action으로 빌드오류 있는지 확인하는거 세팅해두거나 아니면 각자 로컬에서 빌드 돌려보고 빌드오류 해결한 다음 머지해야 할 것 같아요!! (github action으로 하고 싶긴 합니닷)

## 📸 스크린샷
> 화면 캡쳐 이미지

## ✅ 체크리스트
- [x] Reviewers 태그했나요?
- [x] Label 지정했나요?
- [x] 관련 테크스펙 링크 연결했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

- **스타일 및 린팅**
	- ESLint 및 Prettier 구성 파일에 라인 끝 처리 규칙 추가
	- 코드 포맷팅 일관성 개선

- **리팩토링**
	- 모달 및 훅에서 이벤트 핸들러 메서드 이름 개선
	- 코드 가독성 향상을 위한 명명 규칙 업데이트

- **기술적 개선**
	- 클릭 외부 감지 훅의 유연성 향상
	- 참조 처리 타입 정의 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->