### PR TITLE
refactor: 쿼리 자동 무효화 도입 제안

### DIFF
--- a/app/hooks/mutation/usePatchTeacherModal.ts
+++ b/app/hooks/mutation/usePatchTeacherModal.ts
@@ -1,14 +1,12 @@
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useMutation } from "@tanstack/react-query";
 
 import { patchTeacherModal } from "../../actions/patch-teacherModal";
 
 export function usePatchTeacherModal() {
-  const queryClient = useQueryClient();
-
   return useMutation({
     mutationFn: patchTeacherModal,
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["teachers"] });
+    meta: {
+      invalidates: [["teachers"]],
     },
   });
 }

--- a/app/providers/QueryProvider.tsx
+++ b/app/providers/QueryProvider.tsx
@@ -1,12 +1,24 @@
 "use client";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  MutationCache,
+  QueryClient,
+  matchQuery,
+  QueryClientProvider,
+} from "@tanstack/react-query";
 
 const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: {
-      refetchOnWindowFocus: false,
+  mutationCache: new MutationCache({
+    onSuccess: (_data, _variables, _context, mutation) => {
+      queryClient.invalidateQueries({
+        predicate: (query) =>
+          // 일치하는 모든 태그를 한 번에 무효화, 그 외에는 무효화 X
+          mutation.meta?.invalidates?.some((queryKey) =>
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+            matchQuery({ queryKey }, query),
+          ) ?? false,
+      });
     },
-  },
+  }),
 });
 
 export const QueryProvider = ({

--- a/successInvalidDates..d.ts
+++ b/successInvalidDates..d.ts
@@ -1,0 +1,9 @@
+import "@tanstack/react-query";
+
+declare module "@tanstack/react-query" {
+  interface Register {
+    mutationMeta: {
+      invalidates?: Array<QueryKey>;
+    };
+  }
+}


### PR DESCRIPTION
## 🐈 PR 요약
> PR 내용 한 줄로 요약
- 관련 테크스펙 링크 : X

`queryClient.invalidateQueries`가 아닌 meta를 이용한 쿼리 무효화 도입 제안

## ✨ PR 상세
> PR 상세 내용 개조식으로 작성

일단 mutation이후 특정 쿼리를 무효화하는 것은 필요하다고 생각했습니다.
음 예를 들어 유튜브 링크 수정 이후 -> 다시 선생님 목록 불러오기 등과 같이 쓰이는 곳이 많을거라 생각했어요.

하나의 뮤테이션 후 `invalidateQueries`를 여러번 호출하면 가독성 측면에서, 보기 힘들것 같았씁니다. 

또 useQueryClient로 QueryClient를 매번 가져오게 됩니다.

```tsx
const { mutate } = useMutation({
  mutationFn: redeemVoucher,
  onSuccess: () => {
    queryClient.invalidateQueries({ queryKey: "voucher" });
    queryClient.invalidateQueries({ queryKey: "referralHistory" });
    queryClient.invalidateQueries({ queryKey: "referralVoucher" });
... 
  },
});
```
그래서 이 부분을 개선하려고 해보았는데요.

invalidates 필드를 추가하여 뮤테이션에 "태그"(meta)를 지정할 수 있습니다. 이 태그를 사용하여 무효화하려는 쿼리를 대략적으로 일치시킬 수 있습니다

<- meta를 이용해 특정 쿼리만 무효화시킬수 있는 방법이 있습니다.

아래와 같이 무효화시킬 쿼리들을 배열에 넣어주기만 하면 됩니다!
만약 meta에 쿼리 키가 들어간 경우, 해당 쿼리키를 가진 쿼리를 무효화하고, 그렇지 않으면 무효화를 건너뜁니다.

```tsx
export function usePatchTeacherModal() {
  return useMutation({
    mutationFn: patchTeacherModal,
   //요 부분
    meta: {
      invalidates: [["teachers"]],
    },
  });
}
```


## 🚨 참고사항
> 리뷰어들이 알아야 하거나 알면 좋은 참고사항 작성

https://www.yujiseok.blog/post/tanstack-query-automatic-invalidation-after-mutations

https://www.codingmax.net/courses/ko-react-query/section01/lec0026#meta-%EC%98%B5%EC%85%98-%EC%82%AC%EC%9A%A9%ED%95%98%EA%B8%B0

## 📸 스크린샷
> 화면 캡쳐 이미지

## ✅ 체크리스트
- [x] Reviewers 태그했나요?
- [x] Label 지정했나요?
- [ ] 관련 테크스펙 링크 연결했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 돌연변이(Mutation) 쿼리 무효화 방식을 선언적 접근 방식으로 변경
	- React Query의 메타데이터를 통한 쿼리 관리 개선

- **기술적 개선**
	- 쿼리 무효화 로직을 더욱 유연하고 명시적으로 처리
	- TypeScript 타입 정의를 통한 쿼리 관리 안전성 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->