### PR TITLE
feat: MatchingModal UI 구현

### DIFF
--- a/app/components/teacher/MatchingModal.tsx
+++ b/app/components/teacher/MatchingModal.tsx
@@ -1,0 +1,52 @@
+import { useRef, useState } from "react";
+
+import { useClickoutside } from "../../hooks/custom";
+import type { ModalProps } from "../../ui";
+
+interface MatchingModalProps
+  extends Pick<ModalProps, "isOpen" | "message" | "title" | "cancelText"> {
+  status: "REJECT" | "ACCEPT";
+  rejectReason?: string;
+  handleOnCancel?: (rejectreason: string) => void;
+}
+
+export function MatchingModal({ isOpen, ...rest }: MatchingModalProps) {
+  const matchingModalRef = useRef<HTMLDivElement | null>(null);
+  const [rejectReason, setRejectReason] = useState("");
+  useClickoutside(matchingModalRef);
+
+  if (!isOpen) {
+    return null;
+  }
+
+  const modalHeight = rest.status === "ACCEPT" ? "h-[112px]" : "h-[255px]";
+
+  return (
+    <div className="bg-opacity / 36 fixed inset-0 z-10 flex items-center justify-center bg-black bg-opacity-50">
+      <div
+        ref={matchingModalRef}
+        className={`flex ${modalHeight} w-[335px] flex-col justify-center gap-[6px] rounded-[14px] bg-white px-[24px] py-[30px] align-middle`}
+      >
+        <h2 className="text-[16px] font-bold text-[#3A3A3A]">{rest.title}</h2>
+        {rest.status === "ACCEPT" && (
+          <p className="font-md text-[15px] text-[#777777]">{rest.message}</p>
+        )}
+        {rest.status === "REJECT" && (
+          <div className="mt-2 flex flex-col gap-[20px]">
+            <textarea
+              placeholder="이유를 입력해주세요."
+              className="h-[86px] w-[287px] resize-none rounded-[8px] border-2 p-2 font-[14px] text-black"
+              onChange={(e) => setRejectReason(e.target.value)}
+            />
+            <button
+              onClick={() => rest.handleOnCancel?.(rejectReason)}
+              className="h-[50px] w-[138px] rounded-[8px] bg-[#B8B8B8] text-white"
+            >
+              제출하기
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/components/teacher/MatchingModal.tsx
+++ b/app/components/teacher/MatchingModal.tsx
@@ -8,12 +8,13 @@ interface MatchingModalProps
   status: "REJECT" | "ACCEPT";
   rejectReason?: string;
   handleOnCancel?: (rejectreason: string) => void;
+  onCloseModal?: () => void;
 }
 
 export function MatchingModal({ isOpen, ...rest }: MatchingModalProps) {
   const matchingModalRef = useRef<HTMLDivElement | null>(null);
   const [rejectReason, setRejectReason] = useState("");
-  useClickoutside(matchingModalRef);
+  useClickoutside(matchingModalRef, rest.onCloseModal);
 
   if (!isOpen) {
     return null;

--- a/app/components/teacher/MatchingModal.tsx
+++ b/app/components/teacher/MatchingModal.tsx
@@ -3,13 +3,25 @@ import { useRef, useState } from "react";
 import { useClickoutside } from "../../hooks/custom";
 import type { ModalProps } from "../../ui";
 
-interface MatchingModalProps
+type ModalStatus = "REJECT" | "ACCEPT";
+
+interface BaseMatchingModalProps
   extends Pick<ModalProps, "isOpen" | "message" | "title" | "cancelText"> {
-  status: "REJECT" | "ACCEPT";
-  rejectReason?: string;
-  handleOnCancel?: (rejectreason: string) => void;
+  status: ModalStatus;
   onCloseModal?: () => void;
 }
+
+interface AcceptMatchingModalProps extends BaseMatchingModalProps {
+  status: "ACCEPT";
+}
+
+interface RejectMatchingModalProps extends BaseMatchingModalProps {
+  status: "REJECT";
+  rejectReason?: string;
+  onSubmitReject: (reason: string) => void;
+}
+
+type MatchingModalProps = AcceptMatchingModalProps | RejectMatchingModalProps;
 
 export function MatchingModal({ isOpen, ...rest }: MatchingModalProps) {
   const matchingModalRef = useRef<HTMLDivElement | null>(null);

--- a/app/ui/Modal.tsx
+++ b/app/ui/Modal.tsx
@@ -3,7 +3,7 @@ import { useRef } from "react";
 
 import { useClickoutside } from "../hooks/custom";
 
-interface ModalProps {
+export interface ModalProps {
   title: string;
   message: React.ReactNode;
   confirmText: string;


### PR DESCRIPTION
## 🐈 PR 요약
> PR 내용 한 줄로 요약
- 관련 테크스펙 링크 : https://www.notion.so/list-e0e0be947a564f3794bc46f988352c73?p=89e64769949246629be66a50e6af2aa2&pm=s

## ✨ PR 상세
> PR 상세 내용 개조식으로 작성

- 특정 과외 건 수락/거절하는 모달 UI 구현

## 🚨 참고사항
> 리뷰어들이 알아야 하거나 알면 좋은 참고사항 작성

과외를 수락한 경우

```tsx
<MatchingModal
  isOpen={isModalOpen}
  status="ACCEPT"
  title="신청이 완료됐어요!"
  message="선생님의 프로필을 학부모님께 전달드릴게요."
  onCloseModal={closeModal}
/>
```

과외를 거절한 경우
```tsx
<MatchingModal
  isOpen={isModalOpen}
  status="REJECT"
  title="신청을 하지 않는 이유를 알려주세요!"
  message=""
  onCloseModal={closeModal}
/>

```



## 📸 스크린샷
> 화면 캡쳐 이미지
![image](https://github.com/user-attachments/assets/38cc8223-2d91-4698-b7eb-4f3f42ae1ae2)

![image](https://github.com/user-attachments/assets/85bd3fc1-1b0c-4a9b-a566-29c43e11ab60)



## ✅ 체크리스트
- [x] Reviewers 태그했나요?
- [x] Label 지정했나요?
- [x] 관련 테크스펙 링크 연결했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
	- 교사용 매칭 모달 대화상자 추가
	- 모달에서 수락 또는 거절 작업 지원
	- 동적 높이와 상태에 따른 조건부 렌더링 구현

- **개선 사항**
	- 모달 인터페이스의 접근성 향상
	- 외부 클릭 시 모달 닫기 기능 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->