### PR TITLE
refactor: use-server구문 제거, postman mock server로 경로 변경

### DIFF
--- a/__tests__/example.test.tsx
+++ b/__tests__/example.test.tsx
@@ -1,7 +1,7 @@
 import "@testing-library/jest-dom";
 import { render, screen } from "@testing-library/react";
 
-import Home from "../app/(route)/page";
+import Home from "../app/(route)/(admin)/page";
 
 describe("Home", () => {
   it("renders single div tag", () => {

--- a/app/(route)/(teacher)/teacher/[id]/page.tsx
+++ b/app/(route)/(teacher)/teacher/[id]/page.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import IconTitleChip from "../../../../components/teacher/IconTitleChip";
 import ProfileInfoBox from "../../../../components/teacher/ProfileInfoBox";
 import {
@@ -9,11 +11,10 @@ export default function TeacherPage({ params }: { params: { id: string } }) {
   return (
     <div>
       <ProfileInfoBox title="예시 텍스트입니다.">
-        <div>
-          예시텍스트입니다. 예시텍스트입니다. 예시텍스트입니다.
-          예시텍스트입니다. 예시텍스트입니다. 예시텍스트입니다.
-          예시텍스트입니다. 예시텍스트입니다. 예시텍스트입니다.
-        </div>
+        예시텍스트입니다. 예시텍스트입니다. 예시텍스트입니다. 예시텍스트입니다.
+        예시텍스트입니다. 예시텍스트입니다. 예시텍스트입니다. 예시텍스트입니다.
+        예시텍스트입니다.
+        {params.id}
       </ProfileInfoBox>
       <IconTitleChip
         title={`${TEACHER_STYLE_TEXT.passionate} 선생님`}

--- a/app/actions/get-acceptance/index.ts
+++ b/app/actions/get-acceptance/index.ts
@@ -1,5 +1,3 @@
-"use server";
-
 import { z } from "zod";
 import { AxiosError } from "axios";
 

--- a/app/actions/get-matching/index.ts
+++ b/app/actions/get-matching/index.ts
@@ -1,5 +1,3 @@
-"use server";
-
 import { z } from "zod";
 import { AxiosError } from "axios";
 

--- a/app/actions/get-parents-request/index.ts
+++ b/app/actions/get-parents-request/index.ts
@@ -1,5 +1,3 @@
-"use server";
-
 import { z } from "zod";
 import { AxiosError } from "axios";
 

--- a/app/actions/patch-displayname/index.ts
+++ b/app/actions/patch-displayname/index.ts
@@ -1,5 +1,3 @@
-"use server";
-
 import { z } from "zod";
 import { AxiosError } from "axios";
 

--- a/app/actions/post-acceptance/index.ts
+++ b/app/actions/post-acceptance/index.ts
@@ -1,5 +1,3 @@
-"use server";
-
 import { z } from "zod";
 import { AxiosError } from "axios";
 

--- a/app/components/root/TeacherListSearch.tsx
+++ b/app/components/root/TeacherListSearch.tsx
@@ -49,9 +49,9 @@ function TeacherListSearch({
                   alert(data.data);
                   closeModal();
                 },
-                onError: (error) => {
-                  const errorMessage = "알림톡 발송 중 문제가 발생했습니다. 잠시 후 다시 시도해주세요.";
-                  console.error('매칭 알림톡 발송 실패:', error);
+                onError: () => {
+                  const errorMessage =
+                    "알림톡 발송 중 문제가 발생했습니다. 잠시 후 다시 시도해주세요.";
                   alert(errorMessage);
                   closeModal();
                 },

--- a/app/components/teacher/IconTitleChip.tsx
+++ b/app/components/teacher/IconTitleChip.tsx
@@ -9,7 +9,7 @@ function IconTitleChip(props: IconTitleChipProps) {
   const { title, icon } = props;
   return (
     <div className="flex w-fit gap-[6px] rounded-lg bg-gray-100 px-3 py-[10px]">
-      <Image className="h-5 w-5" src={icon} alt="아이콘 이미지" />
+      <Image className="size-5" src={icon} alt="아이콘 이미지" />
       <p className="font-pretendard font-bold leading-[146%] tracking-[-0.02em]">
         {title}
       </p>

--- a/app/constants/teacherStyle.ts
+++ b/app/constants/teacherStyle.ts
@@ -1,4 +1,4 @@
-import solar_fire from "../../public/images/solar_fire.png";
+import SolarFile from "../../public/images/solar_fire.png";
 
 export const TEACHER_STYLE_TEXT = {
   kind: "따뜻하고 친절한",
@@ -10,10 +10,10 @@ export const TEACHER_STYLE_TEXT = {
 } as const;
 
 export const TEACHER_STYLE_ICON = {
-  kind: solar_fire,
-  passionate: solar_fire,
-  meticulous: solar_fire,
-  funny: solar_fire,
-  selfEsteem: solar_fire,
-  skillful: solar_fire,
+  kind: SolarFile,
+  passionate: SolarFile,
+  meticulous: SolarFile,
+  funny: SolarFile,
+  selfEsteem: SolarFile,
+  skillful: SolarFile,
 } as const;

--- a/app/utils/httpService.ts
+++ b/app/utils/httpService.ts
@@ -3,7 +3,7 @@ import axios from "axios";
 const baseURL =
   process.env.NODE_ENV === "development"
     ? "http://localhost:3000" // 개발 모드
-    : ""; // 배포 모드
+    : "https://2658d74c-2d23-41c2-8e9e-010551ee3f7b.mock.pstmn.io"; // 배포 모드
 
 export const httpService = axios.create({
   baseURL,


### PR DESCRIPTION
## 🐈 PR 요약
> PR 내용 한 줄로 요약
- 관련 테크스펙 링크 : X

## ✨ PR 상세
> PR 상세 내용 개조식으로 작성

배포 환경에서 msw가 잘 동작하지 않아서 , 임시로 postman mock server로 데이터를 만들었습니다.

https://2658d74c-2d23-41c2-8e9e-010551ee3f7b.mock.pstmn.io/api/matching/1214124124000

## 🚨 참고사항
> 리뷰어들이 알아야 하거나 알면 좋은 참고사항 작성

https://github.com/mswjs/msw/issues/737 
요 글 보면,,,msw는 확실히 로컬에서 개발할 때의 용도 같아요. 지금처럼 배포할 때는 포스트맨-목업 서버로 하는게 나을거 같아요.?

(이럴거면 첨부터 요거 쓸..걸 그랬네요..하하..)
https://darrenlog.tistory.com/44

## 📸 스크린샷
> 화면 캡쳐 이미지

## ✅ 체크리스트
- [x] Reviewers 태그했나요?
- [x] Label 지정했나요?
- [x] 관련 테크스펙 링크 연결했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
	- 테스트 파일의 컴포넌트 경로 업데이트
	- 일부 서버 액션 관련 코드 정리

- **스타일 변경**
	- 이미지 컴포넌트의 클래스 이름 수정
	- 교사 스타일 아이콘 이미지 변수명 업데이트

- **기타 변경**
	- HTTP 서비스의 프로덕션 환경 기본 URL 수정
	- 교사 목록 검색 컴포넌트의 일부 기능 제거

<!-- end of auto-generated comment: release notes by coderabbit.ai -->