### PR TITLE
refactor : 어드민 페이지에 부분적으로 parrel route 도입

### DIFF
--- a/app/(route)/(admin)/[id]/@adminHeader/error.tsx
+++ b/app/(route)/(admin)/[id]/@adminHeader/error.tsx
@@ -1,0 +1,13 @@
+"use client";
+export default function AdminHeaderError() {
+  return (
+    <div className="flex h-screen items-center justify-center">
+      <div className="rounded bg-red-500 p-4 text-white shadow-md" role="alert">
+        <strong className="font-bold">오류 발생!</strong>
+        <span className="block sm:inline">
+          문제가 발생했습니다. 나중에 다시 시도해 주세요.
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/app/(route)/(admin)/[id]/@adminHeader/loading.tsx
+++ b/app/(route)/(admin)/[id]/@adminHeader/loading.tsx
@@ -1,0 +1,7 @@
+export default function Loading() {
+  return (
+    <div className="flex h-screen items-center justify-center">
+      <div className="size-16 animate-spin rounded-full border-y-4 border-gray-200 border-t-blue-500" />
+    </div>
+  );
+}

--- a/app/(route)/(admin)/[id]/@adminHeader/page.tsx
+++ b/app/(route)/(admin)/[id]/@adminHeader/page.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { useRef } from "react";
+
+import { usePatchMatchingDisplayName } from "../../../../hooks/mutation/usePatchMatchingDisplayname";
+import { useGetMatchingInfo } from "../../../../hooks/query";
+
+interface HeaderProps {
+  params: {
+    matchingId: string;
+  };
+}
+
+export default function AdminHeader({ params }: HeaderProps) {
+  const { data: matchingDetailInfo } = useGetMatchingInfo(params.matchingId);
+  const matchingDisplayNameRef = useRef<HTMLInputElement>(null);
+  const { mutate } = usePatchMatchingDisplayName();
+
+  return (
+    <header className="flex min-h-[80px] items-center gap-4 border-b-2 border-[#E6EFF5] pl-4 font-bold text-headColor">
+      {matchingDetailInfo.data.location} : {matchingDetailInfo.data.subject}
+      <input
+        ref={matchingDisplayNameRef}
+        defaultValue="In the Future"
+        aria-label="표시 이름"
+        maxLength={50}
+        pattern="^[a-zA-Z0-9가-힣\s]+$"
+        className="text-md min-w-28 rounded-2xl bg-[#EFEFEF] px-4"
+      />
+      <button
+        onClick={() =>
+          mutate(
+            {
+              matchingId: params.matchingId,
+              displayName: String(matchingDisplayNameRef?.current?.value),
+            },
+            {
+              onError: () => {
+                alert("저장 중 오류가 발생했습니다. 다시 시도해 주세요.");
+              },
+              onSuccess: () => {
+                alert("성공적으로 저장되었습니다.");
+              },
+            },
+          )
+        }
+        className="mr-4 rounded bg-primary px-3 py-[6px] text-white hover:bg-[#4762B4]"
+      >
+        저장
+      </button>
+    </header>
+  );
+}

--- a/app/(route)/(admin)/[id]/@adminHeader/page.tsx
+++ b/app/(route)/(admin)/[id]/@adminHeader/page.tsx
@@ -7,12 +7,12 @@ import { useGetMatchingInfo } from "../../../../hooks/query";
 
 interface HeaderProps {
   params: {
-    matchingId: string;
+    id: string;
   };
 }
 
 export default function AdminHeader({ params }: HeaderProps) {
-  const { data: matchingDetailInfo } = useGetMatchingInfo(params.matchingId);
+  const { data: matchingDetailInfo } = useGetMatchingInfo(params.id);
   const matchingDisplayNameRef = useRef<HTMLInputElement>(null);
   const { mutate } = usePatchMatchingDisplayName();
 
@@ -31,7 +31,7 @@ export default function AdminHeader({ params }: HeaderProps) {
         onClick={() =>
           mutate(
             {
-              matchingId: params.matchingId,
+              matchingId: params.id,
               displayName: String(matchingDisplayNameRef?.current?.value),
             },
             {

--- a/app/(route)/(admin)/[id]/@alim/error.tsx
+++ b/app/(route)/(admin)/[id]/@alim/error.tsx
@@ -1,0 +1,13 @@
+"use client";
+export default function AdminAlimErrors() {
+  return (
+    <div className="flex h-screen items-center justify-center">
+      <div className="rounded bg-red-500 p-4 text-white shadow-md" role="alert">
+        <strong className="font-bold">오류 발생!</strong>
+        <span className="block sm:inline">
+          문제가 발생했습니다. 나중에 다시 시도해 주세요.
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/app/(route)/(admin)/[id]/@alim/loading.tsx
+++ b/app/(route)/(admin)/[id]/@alim/loading.tsx
@@ -1,0 +1,7 @@
+export default function Loading() {
+  return (
+    <div className="flex h-screen items-center justify-center">
+      <div className="size-16 animate-spin rounded-full border-y-4 border-gray-200 border-t-blue-500" />
+    </div>
+  );
+}

--- a/app/(route)/(admin)/[id]/@alim/page.tsx
+++ b/app/(route)/(admin)/[id]/@alim/page.tsx
@@ -1,11 +1,22 @@
+import { dehydrate, HydrationBoundary } from "@tanstack/react-query";
+
 import { Alim } from "../../../../components/root/Alim";
+import { getQueryClient } from "../../../../utils/getQueryClient";
 
 export default function AlimTableHome({
   params,
 }: {
   params: {
-    matchingId: string;
+    id: string;
   };
 }) {
-  return <Alim id={params.matchingId} />;
+  const queryClient = getQueryClient();
+  queryClient.prefetchQuery({
+    queryKey: ["acceptance", params.id, 1],
+  });
+  return (
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <Alim id={params.id} />
+    </HydrationBoundary>
+  );
 }

--- a/app/(route)/(admin)/[id]/@alim/page.tsx
+++ b/app/(route)/(admin)/[id]/@alim/page.tsx
@@ -1,0 +1,11 @@
+import { Alim } from "../../../../components/root/Alim";
+
+export default function AlimTableHome({
+  params,
+}: {
+  params: {
+    matchingId: string;
+  };
+}) {
+  return <Alim id={params.matchingId} />;
+}

--- a/app/(route)/(admin)/[id]/layout.tsx
+++ b/app/(route)/(admin)/[id]/layout.tsx
@@ -1,0 +1,22 @@
+import { PropsWithChildren, ReactNode } from "react";
+
+type LayoutProps = PropsWithChildren & {
+  adminHeader: ReactNode;
+  alim: ReactNode;
+} & {
+  params: {
+    id: string;
+  };
+};
+
+const Layout = ({ adminHeader, alim, children }: LayoutProps) => {
+  return (
+    <div>
+      {adminHeader}
+      {alim}
+      {children}
+    </div>
+  );
+};
+
+export default Layout;

--- a/app/(route)/(admin)/[id]/page.tsx
+++ b/app/(route)/(admin)/[id]/page.tsx
@@ -1,5 +1,3 @@
-import { Header } from "../../../ui";
-import { Alim } from "../../../components/root/Alim";
 import ParentsRequest from "../../../components/root/ParentsRequest";
 import { Teacher } from "../../../components/root/Teacher";
 
@@ -12,8 +10,6 @@ export default function MatchingDetailHome({
 
   return (
     <div className="flex flex-col">
-      <Header matchingId={id} />
-      <Alim id={id} />
       <ParentsRequest />
       <Teacher matchingId={id} />
     </div>

--- a/app/components/teacher/IconTitleChip.tsx
+++ b/app/components/teacher/IconTitleChip.tsx
@@ -8,7 +8,7 @@ interface IconTitleChipProps {
 function IconTitleChip(props: IconTitleChipProps) {
   const { title, icon } = props;
   return (
-    <div className="bg-primaryTint flex w-fit gap-[6px] rounded-lg px-3 py-[10px]">
+    <div className="flex w-fit gap-[6px] rounded-lg bg-primaryTint px-3 py-[10px]">
       <Image
         className="size-5"
         src={icon}

--- a/app/components/teacher/MatchingModal.tsx
+++ b/app/components/teacher/MatchingModal.tsx
@@ -53,7 +53,7 @@ export function MatchingModal({ isOpen, ...rest }: MatchingModalProps) {
             width={10}
             height={10}
             onClick={() => rest.onCloseModal?.()}
-            onKeyDown={(e) => e.key === 'Enter' && rest.onCloseModal?.()}
+            onKeyDown={(e) => e.key === "Enter" && rest.onCloseModal?.()}
             role="button"
             tabIndex={0}
             className="flex justify-end"
@@ -67,7 +67,7 @@ export function MatchingModal({ isOpen, ...rest }: MatchingModalProps) {
           </p>
         )}
         {rest.status === "REJECT" && (
-          <div className="mx-auto mt-[20px] flex w-[287px] flex-col gap-[12px] text-[#3C434F]">
+          <div className="mx-auto mt-[20px] flex w-[287px] flex-col gap-[12px] text-labelNormal">
             <label className="flex items-center justify-between">
               가능한 시간이 아니에요
               <input

--- a/app/components/teacher/MatchingProposal.tsx
+++ b/app/components/teacher/MatchingProposal.tsx
@@ -46,7 +46,8 @@ export function MatchingProposal({
       <ProfileInfoBox
         title={
           <p>
-            이런 <span className="text-[#3265FD]">목적</span>에 집중하고 싶어요.
+            이런 <span className="text-primaryNormal">목적</span>에 집중하고
+            싶어요.
           </p>
         }
       >
@@ -65,7 +66,8 @@ export function MatchingProposal({
       <ProfileInfoBox
         title={
           <p>
-            학부모님이 <span className="text-[#3265FD]">선호하는 선생님</span>
+            학부모님이{" "}
+            <span className="text-primaryNormal">선호하는 선생님</span>
             이에요.
           </p>
         }
@@ -76,7 +78,7 @@ export function MatchingProposal({
       <ProfileInfoBox
         title={
           <p>
-            학부모님이 <span className="text-[#3265FD]">선호하는 시간</span>
+            학부모님이 <span className="text-primaryNormal">선호하는 시간</span>
             이에요.
           </p>
         }
@@ -84,7 +86,7 @@ export function MatchingProposal({
         {data.data.wantTime}
       </ProfileInfoBox>
       <button
-        className="order-0 flex h-[58px] w-[335px] flex-none flex-row items-center justify-center gap-[6px] self-stretch rounded-[8px] bg-[#3265FD] p-[16px] px-[36px] font-bold text-white"
+        className="order-0 flex h-[58px] w-[335px] flex-none flex-row items-center justify-center gap-[6px] self-stretch rounded-[8px] bg-primaryNormal p-[16px] px-[36px] font-bold text-white"
         onClick={() => {
           setMatchingStatus("ACCEPT");
           openModal();
@@ -97,7 +99,7 @@ export function MatchingProposal({
         신청하기
       </button>
       <button
-        className="mx-auto my-[18px] flex justify-center border-b-2 text-[#757679]"
+        className="mx-auto my-[18px] flex justify-center border-b-2 text-labelNeutral"
         onClick={() => {
           setMatchingStatus("REJECT");
           openModal();

--- a/app/hooks/query/useGetAcceptance.ts
+++ b/app/hooks/query/useGetAcceptance.ts
@@ -9,5 +9,11 @@ export function useGetAcceptance(matchingId: string, page: number) {
   return useSuspenseQuery<AcceptanceSchema>({
     queryKey: ["acceptance", matchingId, page],
     queryFn: () => getAcceptance(matchingId),
+    staleTime: 0,
+    initialData: {
+      lastUpdated: "",
+      data: [],
+      status: "SUCCESS",
+    },
   });
 }

--- a/app/hooks/query/useGetAcceptance.ts
+++ b/app/hooks/query/useGetAcceptance.ts
@@ -9,11 +9,7 @@ export function useGetAcceptance(matchingId: string, page: number) {
   return useSuspenseQuery<AcceptanceSchema>({
     queryKey: ["acceptance", matchingId, page],
     queryFn: () => getAcceptance(matchingId),
-    staleTime: 0,
-    initialData: {
-      lastUpdated: "",
-      data: [],
-      status: "SUCCESS",
-    },
+    staleTime: 5 * 10 * 6000,
+    gcTime: 5 * 10 * 6000,
   });
 }

--- a/app/hooks/query/useGetMatchingInfo.ts
+++ b/app/hooks/query/useGetMatchingInfo.ts
@@ -6,5 +6,16 @@ export function useGetMatchingInfo(matchingId: string) {
   return useSuspenseQuery({
     queryKey: ["matching", matchingId],
     queryFn: () => getMatching(matchingId),
+    staleTime: Infinity,
+    gcTime: Infinity,
+    initialData: {
+      status: "REJECTED",
+      data: {
+        subject: [],
+        displayName: "",
+        createdAt: "",
+        location: [],
+      },
+    },
   });
 }

--- a/app/providers/QueryProvider.tsx
+++ b/app/providers/QueryProvider.tsx
@@ -7,6 +7,11 @@ import {
 } from "@tanstack/react-query";
 
 const queryClient = new QueryClient({
+  defaultOptions: {
+    dehydrate: {
+      shouldDehydrateQuery: (query) => query.state.status === "pending",
+    },
+  },
   mutationCache: new MutationCache({
     onSuccess: (_data, _variables, _context, mutation) => {
       queryClient.invalidateQueries({

--- a/app/utils/getQueryClient.tsx
+++ b/app/utils/getQueryClient.tsx
@@ -1,0 +1,39 @@
+import {
+  MutationCache,
+  QueryClient,
+  isServer,
+  matchQuery,
+} from "@tanstack/react-query";
+
+function makeQueryClient() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      dehydrate: {
+        shouldDehydrateQuery: (query) => query.state.status === "pending",
+      },
+    },
+    mutationCache: new MutationCache({
+      onSuccess: (_data, _variables, _context, mutation) => {
+        queryClient.invalidateQueries({
+          predicate: (query) =>
+            // 일치하는 모든 태그를 한 번에 무효화, 그 외에는 무효화 X
+            mutation.meta?.invalidates?.some((queryKey) =>
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+              matchQuery({ queryKey }, query),
+            ) ?? false,
+        });
+      },
+    }),
+  });
+  return queryClient;
+}
+
+export function getQueryClient() {
+  let browserQueryClient: QueryClient | undefined;
+  if (isServer) {
+    return makeQueryClient();
+  } else {
+    if (!browserQueryClient) browserQueryClient = makeQueryClient();
+    return browserQueryClient;
+  }
+}


### PR DESCRIPTION
## 🐈 PR 요약
> PR 내용 한 줄로 요약
- 관련 테크스펙 링크 : X

## ✨ PR 상세
> PR 상세 내용 개조식으로 작성

어드민 부분에서 부분적으로 parrel route를 도입했습니다.
제가 가장 인상적이었던 부분은 빌드 후, 아래 이미지의 `Size`의 크기가 좀 많이 줄어들었더라고요 (42KB -> 7KB)

다만 First load js부분은 줄어들지 않았습니다..

어떻게 보면 어드민 페이지에서 2개의 테이블이기에, parrel route를 사용해도 괜찮겠다 싶었어요,
제가 생각했을 때 가장 큰 장점(parrel route)은 `관심사의 분리`인 것 같습니다.

- 각 페이지의 로딩 상태와 에러 상태를 분리하여 관리할 수 있다.
- 내부 컴포넌트의 복잡한 분기처리를 줄일 수 있다.
- 독립적으로 페이지를 분리하여 레이아웃이 거대해지는 것을 막을 수 있다.

폴더 구조도, @경로에 따라 구분할 수 있을 것도 같고,, 음음 잘 쓰기만 하면 유용할 거 같아요!

## 🚨 참고사항
> 리뷰어들이 알아야 하거나 알면 좋은 참고사항 작성

https://min-kyung.tistory.com/200

## 📸 스크린샷
> 화면 캡쳐 이미지

[새 방식]
<img width="1470" alt="스크린샷 2025-02-03 오후 4 13 22" src="https://github.com/user-attachments/assets/51d61635-0cf6-4953-838e-51029a10a027" />

[기존 방식]
<img width="1470" alt="스크린샷 2025-02-03 오후 4 15 37" src="https://github.com/user-attachments/assets/d0f9c824-d201-40a1-b1b9-acc3e7461227" />

## ✅ 체크리스트
- [x] Reviewers 태그했나요?
- [x] Label 지정했나요?
- [ ] 관련 테크스펙 링크 연결했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
	- 관리 페이지에 에러 메시지와 로딩 상태를 명확하게 표시하는 새로운 컴포넌트를 추가했습니다.
	- 데이터 표시, 입력값 수정 및 저장 기능을 포함한 관리자 헤더와 홈 화면 레이아웃을 도입하여 인터페이스를 개선했습니다.
	- 기존 페이지에서 불필요한 헤더 요소를 제거해 UI를 간소화했습니다.
- **스타일**
	- 강사 관련 모달 및 버튼 등의 색상과 시각적 요소를 업데이트하여 디자인 일관성을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->