### PR TITLE
fix: 선생님 수락/보류 페이지 세부 멘트 + 스타일 디테일 수정

### DIFF
--- a/app/(route)/(admin)/zuzuclubadmin/settle-management/page.tsx
+++ b/app/(route)/(admin)/zuzuclubadmin/settle-management/page.tsx
@@ -1,3 +1,3 @@
 export default function SettleManagementHome() {
-  return <div className="p-4 pt-2 font-pretendard">정산관리</div>;
+  return <div className="p-4 pt-2">정산관리</div>;
 }

--- a/app/(route)/globals.css
+++ b/app/(route)/globals.css
@@ -4,4 +4,5 @@
 
 :root {
   --background: #f5f7fa;
+  font-family: Pretendard;
 }

--- a/app/components/teacher/MatchingInfo.tsx
+++ b/app/components/teacher/MatchingInfo.tsx
@@ -1,9 +1,10 @@
 import { TutoringResponse } from "../../actions/get-tutoring";
 
 export function MatchingInfo(props: TutoringResponse) {
-  const activeLocation = props.online
-    ? "비대면"
-    : String(props.district + "\n" + props.dong);
+  const activeLocation =
+    props.online === "비대면"
+      ? "비대면"
+      : String(props.district + "\n" + props.dong);
 
   const extractClassTime = (timeString: string) => {
     const match = timeString.match(/\d+/);
@@ -14,7 +15,7 @@ export function MatchingInfo(props: TutoringResponse) {
   const classFee = 500 * classTimeInMinutes;
 
   return (
-    <div className="ml-[16px] flex min-h-[250px] min-w-[335px] flex-col justify-center gap-[42px] rounded-[12px] bg-primaryLight px-5 py-[46px] align-middle">
+    <div className="mx-auto flex h-[247px] w-[89%] flex-col justify-center gap-[18px] rounded-[12px] bg-primaryLight px-5 py-[46px] align-middle font-pretendard">
       <div className="flex w-[287px] justify-between">
         <div className="text-[#616161]">과목</div>
         <div className="font-semibold text-[#171719]">{props.classType}</div>
@@ -25,7 +26,9 @@ export function MatchingInfo(props: TutoringResponse) {
       </div>
       <div className="flex w-[287px] justify-between">
         <div className="text-[#616161]">수업시수</div>
-        <div className="font-semibold text-[#171719]">{props.classCount}</div>
+        <div className="font-semibold text-[#171719]">
+          {props.classCount + " " + props.classTime}
+        </div>
       </div>
       <div className="flex w-[287px] justify-between">
         <div className="text-[#616161]">수업료</div>

--- a/app/components/teacher/MatchingModal.tsx
+++ b/app/components/teacher/MatchingModal.tsx
@@ -72,14 +72,14 @@ export function MatchingModal({ isOpen, ...rest }: MatchingModalProps) {
         {rest.status === "REJECT" && (
           <div className="mx-auto mt-[20px] flex w-[287px] flex-col gap-[12px] text-labelNormal">
             <label
-              className={`flex items-center justify-between ${rejectReason === "시간이 안 맞아요" ? "font-bold" : ""}`}
+              className={`flex items-center justify-between ${rejectReason === "시간이 맞지 않아요" ? "font-bold" : ""}`}
             >
-              가능한 시간이 아니에요
+              시간이 맞지 않아요
               <input
                 className="scale-150"
                 type="radio"
                 name="rejectReason"
-                value="시간이 안 맞아요"
+                value="시간이 맞지 않아요"
                 onChange={(e) => {
                   setShowETCRejectReason(false);
                   setRejectReason(e.target.value);
@@ -118,14 +118,14 @@ export function MatchingModal({ isOpen, ...rest }: MatchingModalProps) {
               />
             </label>
             <label
-              className={`flex items-center justify-between ${rejectReason === "현재 수업이 불가한 상태에요" ? "font-bold" : ""}`}
+              className={`flex items-center justify-between ${rejectReason === "지금은 수업이 불가해요" ? "font-bold" : ""}`}
             >
-              현재 수업이 불가한 상태에요
+              지금은 수업이 불가해요
               <input
                 className="scale-150"
                 type="radio"
                 name="rejectReason"
-                value="현재 수업이 불가한 상태에요"
+                value="지금은 수업이 불가해요"
                 onChange={(e) => {
                   setShowETCRejectReason(false);
                   setRejectReason(e.target.value);
@@ -135,12 +135,12 @@ export function MatchingModal({ isOpen, ...rest }: MatchingModalProps) {
             <label
               className={`flex items-center justify-between ${showETCRejectReason === true ? "font-bold" : ""}`}
             >
-              기타
+              다른 이유가 있어요
               <input
                 className="scale-150"
                 type="radio"
                 name="rejectReason"
-                value="기타"
+                value="다른 이유가 있어요"
                 onChange={() => setShowETCRejectReason(true)}
               />
             </label>

--- a/app/components/teacher/MatchingProposal.tsx
+++ b/app/components/teacher/MatchingProposal.tsx
@@ -44,19 +44,19 @@ export function MatchingProposal({
     title: ReactNode;
     content: ReactNode;
   }>({
-    title: "신청이 완료됐어요.",
-    content: "선생님의 프로필을 학부모님께 전달드릴게요",
+    title: "신청이 완료됐어요!",
+    content: "선생님의 프로필을 학부모님께 전달드릴게요.",
   });
 
   const modalTitle =
     matchingStatus === "ACCEPT"
       ? rejectSuccessMessage.title
-      : "넘기는 이유를 알려주세요.";
+      : "신청하지 않으시는 이유를 알려주세요.";
 
   const modalSubTitle =
     matchingStatus === "ACCEPT" ? rejectSuccessMessage.content : "";
   return (
-    <section>
+    <section className="font-pretendard">
       <p className="mb-[15px] ml-[16px] mt-[36px] font-pretendard text-lg font-bold leading-[146%] tracking-[-0.02em] text-gray-800">
         <span className="text-primaryNormal">{data.applicationFormId}</span>{" "}
         과외건
@@ -164,7 +164,7 @@ export function MatchingProposal({
                 setRejectSuccessMessage({
                   title: "이번 과외는 넘길게요!",
                   content:
-                    "희망하지 않는 지역이나 과목의 과외건이 \n 반복전송된다면 고객센터를 통해 알려주세요.",
+                    "희망하지 않는 지역이나 과목의 과외건이 \n 반복 전송된다면 고객센터를 통해 알려주세요.",
                 });
               },
             },


### PR DESCRIPTION
## 🐈 PR 요약
> PR 내용 한 줄로 요약
- 관련 테크스펙 링크 : https://www.notion.so/89e64769949246629be66a50e6af2aa2

## ✨ PR 상세
> PR 상세 내용 개조식으로 작성
- 선생님 수락/보류 페이지 연결했던 거 DB 데이터로 ① 정보 잘 불러와지는지 ② 수락 잘 되는지 ③ 보류 잘 되는지 점검 완료했습니다!
- 추가로 효중님이 작업해셨을 때랑 지금이랑 UI나 문구들이 달라진 부분이 좀 있어서 피그마로 보면서 이번에 다 맞췄습니다!

## 🚨 참고사항
> 리뷰어들이 알아야 하거나 알면 좋은 참고사항 작성
- 문구, 폰트, 정렬 등등 자잘자잘한 작업 하긴 했는데 아직 조금 틀어진 부분이 있는 것 같기도?! QA 하면서 더 자세히 잡으면 좋을 것 같습니다!
- 그리고 어차피 개발서버에서 QA 할 거긴 하지만 이 PR 머지되면 `develop`을 `main`에 한번 올리겠습니다! (1차 완성 같은 느낌으로)

## 📸 스크린샷
> 화면 캡쳐 이미지
![image](https://github.com/user-attachments/assets/aac0da58-0baa-4205-b0ae-5188b90c916e)

모달 부분은 텍스트만 바뀐 거라 UI 캡쳐는 생략합니다!
이부분은 정렬, gap, width, height 등등 바꾸었고, 수업시수에서 '주n회'만 나오고 몇분인지 안 나오는 문제 수정, 무조건 '비대면'으로만 나오던 문제 수정했습니다!!

## ✅ 체크리스트
- [x] Reviewers 태그했나요?
- [x] Label 지정했나요?
- [x] 관련 테크스펙 링크 연결했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **스타일**
	- 튜터링 정보 화면이 개선되어 수업 수와 시간이 함께 표시되고, 레이아웃이 조정되었습니다.
	- 반려 사유 모달의 텍스트가 업데이트되어 '시간이 맞지 않아요', '지금은 수업이 불가해요', '다른 이유가 있어요' 등의 표현이 더욱 명확해졌습니다.
	- 제안 반려 성공 메시지와 모달 타이틀 문구가 수정되어 사용자 안내가 한층 명료해졌습니다.
	- 기본 글꼴이 'Pretendard'로 설정되어 텍스트 렌더링 스타일이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->