### PR TITLE
fix: 선생님 상세 페이지 + 선생님 수락/보류 페이지 위주 QA 버그 픽스

### DIFF
--- a/app/components/teacher/MatchingInfo.tsx
+++ b/app/components/teacher/MatchingInfo.tsx
@@ -4,7 +4,7 @@ export function MatchingInfo(props: TutoringResponse) {
   const activeLocation =
     props.online === "비대면"
       ? "비대면"
-      : String(props.district + "\n" + props.dong);
+      : `대면(${props.district} ${props.dong})`;
 
   const extractClassTime = (timeString: string) => {
     const match = timeString.match(/\d+/);

--- a/app/components/teacher/MatchingModal.tsx
+++ b/app/components/teacher/MatchingModal.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import Image from "next/image";
 
 import ModalCloseImage from "../../../public/images/ModalClose.svg";
@@ -31,6 +31,10 @@ export function MatchingModal({ isOpen, ...rest }: MatchingModalProps) {
   useClickoutside(matchingModalRef, rest.onCloseModal);
   const [showETCRejectReason, setShowETCRejectReason] = useState(false);
 
+  useEffect(() => {
+    if (showETCRejectReason) setRejectReason("");
+  }, [showETCRejectReason]);
+
   if (!isOpen) {
     return null;
   }
@@ -53,7 +57,11 @@ export function MatchingModal({ isOpen, ...rest }: MatchingModalProps) {
             src={ModalCloseImage as string}
             width={10}
             height={10}
-            onClick={() => rest.onCloseModal?.()}
+            onClick={() => {
+              setRejectReason("");
+              setShowETCRejectReason(false);
+              rest.onCloseModal?.();
+            }}
             onKeyDown={(e) => e.key === "Enter" && rest.onCloseModal?.()}
             role="button"
             tabIndex={0}

--- a/app/components/teacher/ProfileImageName.tsx
+++ b/app/components/teacher/ProfileImageName.tsx
@@ -16,7 +16,7 @@ export default function ProfileImageName(props: ProfileImageNameProps) {
           alt="프로필 이미지"
           width={110}
           height={110}
-          className="h-auto w-[110px]"
+          className="h-auto w-[110px] rounded-xl"
         />
       ) : (
         <div className="h-[180px] w-[110px] rounded-xl bg-gray-200" />

--- a/app/components/teacher/ProfileImageName.tsx
+++ b/app/components/teacher/ProfileImageName.tsx
@@ -9,7 +9,7 @@ export default function ProfileImageName(props: ProfileImageNameProps) {
   const { imgSrc, name } = props;
 
   return (
-    <div className="flex w-[121px] flex-col items-center gap-4">
+    <div className="flex w-auto flex-col items-center gap-4 text-center">
       {imgSrc ? (
         <Image
           src={imgSrc}

--- a/app/components/teacher/TeacherDetail/TeacherDetailMain.tsx
+++ b/app/components/teacher/TeacherDetail/TeacherDetailMain.tsx
@@ -47,7 +47,7 @@ export default function TeacherDetailMain() {
                   ]}
                 />
                 <ToggleBox
-                  title={`${subject === "english" ? "영어" : "수학"}(${data.data.teachingHistory}년)`}
+                  title={`${subject === "english" ? "영어" : "수학"} 수업(${data.data.teachingHistory}년)`}
                   items={data.data.teachingExperiences}
                 />
                 {data.data.foreignExperiences && (

--- a/app/utils/formatAvailableTimes.ts
+++ b/app/utils/formatAvailableTimes.ts
@@ -1,24 +1,37 @@
 import { DayOfWeek } from "../actions/get-teacher-detail";
 
+/** 연속된 시간대를 그룹화하는 함수 */
+function groupTimes(times: string[]): string {
+  if (times.length === 0) return "불가";
+
+  // 시간 데이터 숫자로 변환 및 정렬
+  const sortedTimes = times
+    .map((time) => parseInt(time.split(":")[0], 10))
+    .sort((a, b) => a - b);
+
+  const timeRanges: string[] = [];
+  let start = sortedTimes[0];
+  let prev = start;
+
+  for (let i = 1; i < sortedTimes.length; i++) {
+    if (sortedTimes[i] !== prev + 1) {
+      // 연속되지 않으면 이전까지의 범위를 저장
+      timeRanges.push(`${start}시 - ${prev + 1}시`);
+      start = sortedTimes[i];
+    }
+    prev = sortedTimes[i];
+  }
+  // 마지막 범위 추가
+  timeRanges.push(`${start}시 - ${prev + 1}시`);
+
+  return timeRanges.join(", ");
+}
+
 /** '요일: 시간' 형태로 만드는 함수 */
 export function formatAvailableTimes(availableTimes: {
   [key in DayOfWeek]: Array<string>;
 }): string[] {
   return Object.entries(availableTimes).map(([day, times]) => {
-    if (times.length === 0) {
-      return `${day}: 불가`;
-    }
-
-    const formattedTimes = times
-      .map((time) => {
-        const [hour, minute] = time.split(":");
-        const hourFormatted = parseInt(hour, 10);
-        const minuteFormatted =
-          minute === "00" ? "" : ` ${parseInt(minute, 10)}분`;
-        return `${hourFormatted}시${minuteFormatted}`;
-      })
-      .join(", ");
-
-    return `${day}: ${formattedTimes}`;
+    return `${day}: ${groupTimes(times)}`;
   });
 }


### PR DESCRIPTION
## 🐈 PR 요약
> PR 내용 한 줄로 요약
- 관련 테크스펙 링크 : X
- 선생님 상세 페이지, 선생님 수락/보류 페이지 위주 QA 픽스

## ✨ PR 상세
> PR 상세 내용 개조식으로 작성
- 선생님 상세 페이지
  - 선생님 이름 길어졌을 때 줄바꿈 되어버리는 문제 수정
  - 선생님 프로필 사진 border-radius 추가
  - 선생님 선호시간 표기 문제 수정 (12시, 14시, 15시로 들어오면 12시 - 13시, 14시 - 16시로 표기될 수 있게 수정함)
  - 영어/수학 '수업' 문구 수정
- 선생님 수락/보류 페이지
  - 보류 모달 선택한 뒤 모달 X 누르고 다시 들어갔을 때 이전에 선택된 항목 bold 남아 있는 문제 수정
  - 보류 모달에서 '다른 이유가 있어요'와 그외 4개 중 하나를 각각 선택했을 때 둘다 bold 처리 되어버리는 문제 수정
  - '대면'인 경우 '대면(ㅇㅇ구 ㅇㅇ동)'으로 표기되게 수정


## 🚨 참고사항
> 리뷰어들이 알아야 하거나 알면 좋은 참고사항 작성
- 수락/보류 선택 후 재진입 시 UI 바뀌는 게 우선순위 더 높은데 api 바뀌기 전까지는 처리하기 애매한 것 같아서 간단한 것들부터 빠르게 해결했습니다!

## 📸 스크린샷
> 화면 캡쳐 이미지

## ✅ 체크리스트
- [x] Reviewers 태그했나요?
- [x] Label 지정했나요?
- [x] 관련 테크스펙 링크 연결했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **스타일**
  - 대면 수업 정보 표기가 “대면(지역 정보)” 형식으로 개선되어, 사용자에게 보다 명확하게 전달됩니다.
  - 프로필 이미지의 크기 유연성과 둥근 모서리 스타일이 적용되어 디자인이 개선되었습니다.
  - 교사 상세 페이지의 수업 제목이 “수업” 단어를 포함하도록 변경되어 가독성이 향상되었습니다.
  
- **새로운 기능**
  - 모달 창에서 “다른 이유가 있어요” 선택 시 입력 내용이 초기화되어, 항상 깔끔한 상태로 확인할 수 있습니다.
  - 이용 가능 시간이 연속된 시간대 범위로 그룹화되어 간결하게 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->