### PR TITLE
fix: 선생님 상세 페이지 + 선생님 수락/보류 페이지 QA 오류 해결

### DIFF
--- a/app/components/teacher/MatchingProposal.tsx
+++ b/app/components/teacher/MatchingProposal.tsx
@@ -157,7 +157,7 @@ export function MatchingProposal({
 
       {["거절", "수락", "전송"].includes(finalStatus) && (
         <div className="mb-6 flex w-full justify-center">
-          <button className="h-[58px] w-[89%] rounded-xl bg-statusInactive text-lg font-bold text-labelAssistive">
+          <button className="h-[58px] w-[89%] cursor-not-allowed rounded-xl bg-statusInactive text-lg font-bold text-labelAssistive">
             {finalStatus === "거절"
               ? "이미 넘긴 수업입니다."
               : "이미 수락한 수업입니다."}

--- a/app/components/teacher/ProfileInfoBox.tsx
+++ b/app/components/teacher/ProfileInfoBox.tsx
@@ -14,7 +14,7 @@ function ProfileInfoBox(props: ProfileInfoBoxProps) {
         {/* ↑ 웬만한 공통 스타일은 기본으로 정의해 두겠습니다! */}
         {title}
       </div>
-      <div className="font-pretendard text-[15px] text-gray-900">
+      <div className="whitespace-pre-wrap font-pretendard text-[15px] text-gray-900">
         {children}
       </div>
     </div>

--- a/app/components/teacher/TeacherDetail/TeacherDetailMain.tsx
+++ b/app/components/teacher/TeacherDetail/TeacherDetailMain.tsx
@@ -52,12 +52,13 @@ export default function TeacherDetailMain() {
                   title={`${subject === "english" ? "영어" : "수학"} 수업(${data.data.teachingHistory}년)`}
                   items={data.data.teachingExperiences}
                 />
-                {data.data.foreignExperiences && (
-                  <ToggleBox
-                    title="해외 경험"
-                    items={data.data.foreignExperiences}
-                  />
-                )}
+                {data.data.foreignExperiences &&
+                  data.data.foreignExperiences.length > 0 && (
+                    <ToggleBox
+                      title="해외 경험"
+                      items={data.data.foreignExperiences}
+                    />
+                  )}
               </div>
             </ProfileInfoBox>
             <ProfileInfoBox

--- a/app/hooks/query/useGetTeacherDetails.ts
+++ b/app/hooks/query/useGetTeacherDetails.ts
@@ -16,6 +16,7 @@ export function useGetTeacherDetailsTeacher(params: TeacherDetailsParams) {
       const res = getTeacherDetailsTeacher(params);
       return res;
     },
+    retry: 0,
     staleTime: 1000 * 60 * 60,
     gcTime: 1000 * 60 * 60 * 24,
   });
@@ -28,6 +29,7 @@ export function useGetTeacherDetailsClass(params: TeacherDetailsParams) {
       const res = getTeacherDetailsClass(params);
       return res;
     },
+    retry: 0,
     staleTime: 1000 * 60 * 60,
     gcTime: 1000 * 60 * 60 * 24,
   });
@@ -42,6 +44,7 @@ export function useGetTeacherDetailsAvailable(
       const res = getTeacherDetailsAvailable(params);
       return res;
     },
+    retry: 0,
     staleTime: 1000 * 60 * 60,
     gcTime: 1000 * 60 * 60 * 24,
   });
@@ -54,6 +57,7 @@ export function useGetTeacherDetailsInfo(params: TeacherSimpleDetailsParams) {
       const res = getTeacherDetailsInfo(params);
       return res;
     },
+    retry: 0,
     staleTime: 1000 * 60 * 60,
     gcTime: 1000 * 60 * 60 * 24,
   });


### PR DESCRIPTION
## 🐈 PR 요약
> PR 내용 한 줄로 요약
- 관련 테크스펙 링크 : X
- 선생님 상세 페이지 + 수락/보류 페이지 QA 오류 해결

## ✨ PR 상세
> PR 상세 내용 개조식으로 작성
- `이미 수락한 수업입니다`, `이미 넘긴 수업입니다` 버튼이 `cursor: pointer;`로 되어 있어서 `cursor: not-allowed`로 변경
- 해외 경험 아예 없는 선생님일 경우, 빈 컴포넌트가 아닌 아예 해외경험 컴포넌트 안 보여주는 걸로 변경
- 선생님 상세 페이지 줄바꿈 처리 추가 (프로필 작성자가 의도한대로 줄바꿈이 들어갈 수 있도록)
- `useGetTeacherDetails` `retry: 0` 처리

## 🚨 참고사항
> 리뷰어들이 알아야 하거나 알면 좋은 참고사항 작성
- 근데 생각해 보니 `retry` 0번으로 하는 건 임시방편일 것 같구 로딩 처리 하는 게 베스트이긴 하겟네요 흠흠,, 우선순위 낮게 두고 한번 해보겟습니닷

## 📸 스크린샷
> 화면 캡쳐 이미지
![image](https://github.com/user-attachments/assets/d6e56f5f-0a9f-4645-9d06-232371d52075)

줄바꿈 처리

![image](https://github.com/user-attachments/assets/9d409216-58a9-4e55-954b-6357d6a99385)

+) 커서는 캡쳐가 안되네요... 이런 식으로 보여진다고 생각해 주시면 될 것 같습니다!!!

## ✅ 체크리스트
- [x] Reviewers 태그했나요?
- [x] Label 지정했나요?
- [x] 관련 테크스펙 링크 연결했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **스타일**
  - 버튼이 비활성 상태임을 명확하게 표시하도록 디자인을 개선했습니다.
  - 프로필 정보 영역의 텍스트 형식을 개선하여 공백 보존 및 줄바꿈 처리를 향상시켰습니다.
  
- **버그 수정**
  - 외국 경험 항목이 실제로 존재할 때만 표시되도록 렌더링 조건을 강화했습니다.
  
- **Chores**
  - 데이터 요청 시 자동 재시도를 중지하여 요청 동작을 최적화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->