### PR TITLE
fix: 선생님 수락/보류 페이지 오류 처리 + 각종 null 처리 추가

### DIFF
--- a/app/(route)/(teacher)/teacher/[id]/[formId]/[phone]/page.tsx
+++ b/app/(route)/(teacher)/teacher/[id]/[formId]/[phone]/page.tsx
@@ -1,4 +1,5 @@
 import { ErrorBoundary } from "react-error-boundary";
+
 import { MatchingProposal } from "../../../../../../components/teacher/MatchingProposal";
 import ErrorUI from "../../../../../../ui/ErrorUI";
 

--- a/app/(route)/(teacher)/teacher/[id]/[formId]/[phone]/page.tsx
+++ b/app/(route)/(teacher)/teacher/[id]/[formId]/[phone]/page.tsx
@@ -1,4 +1,6 @@
+import { ErrorBoundary } from "react-error-boundary";
 import { MatchingProposal } from "../../../../../../components/teacher/MatchingProposal";
+import ErrorUI from "../../../../../../ui/ErrorUI";
 
 export default function TeacherApplyPage({
   params,
@@ -12,12 +14,14 @@ export default function TeacherApplyPage({
   const { id, formId, phone } = params;
 
   return (
-    <div>
-      <MatchingProposal
-        teacherId={id}
-        phoneNumber={phone}
-        applcationFormId={formId}
-      />
-    </div>
+    <ErrorBoundary fallback={<ErrorUI />}>
+      <div>
+        <MatchingProposal
+          teacherId={id}
+          phoneNumber={phone}
+          applcationFormId={formId}
+        />
+      </div>
+    </ErrorBoundary>
   );
 }

--- a/app/components/teacher/MatchingProposal.tsx
+++ b/app/components/teacher/MatchingProposal.tsx
@@ -28,7 +28,7 @@ export function MatchingProposal({
   phoneNumber,
   applcationFormId,
 }: MatchingProposalProps) {
-  const { data } = useGetTutoring({
+  const { data, error } = useGetTutoring({
     teacherId,
     applcationFormId,
     phoneNumber,
@@ -42,6 +42,8 @@ export function MatchingProposal({
   >(data.matchStatus);
   const { mutate: postTutoringAccept } = usePostTutoringAccept();
   const { mutate: postTutoringReject } = usePostTutoringRefuse();
+
+  if (error) throw error;
 
   const [rejectSuccessMessage, setRejectSuccessMessage] = useState<{
     title: ReactNode;

--- a/app/components/teacher/TeacherDetail/TeacherDetailClass.tsx
+++ b/app/components/teacher/TeacherDetail/TeacherDetailClass.tsx
@@ -34,18 +34,21 @@ export default function TeacherDetailClass() {
           >
             {data.data.teachingStyle}
           </ProfileInfoBox>
-          <ProfileInfoBox
-            title={
-              <p className="whitespace-pre-line">
-                {subject === "english" ? "영어" : "수학"} 역량을 키울 수 있도록
-                {"\n"}
-                <span className="text-primaryNormal">학생 관리</span>는 이렇게
-                해요!
-              </p>
-            }
-          >
-            {data.data.managementStyle}
-          </ProfileInfoBox>
+          {data.data.managementStyle && (
+            <ProfileInfoBox
+              title={
+                <p className="whitespace-pre-line">
+                  {subject === "english" ? "영어" : "수학"} 역량을 키울 수
+                  있도록
+                  {"\n"}
+                  <span className="text-primaryNormal">학생 관리</span>는 이렇게
+                  해요!
+                </p>
+              }
+            >
+              {data.data.managementStyle}
+            </ProfileInfoBox>
+          )}
           {data.data.video && (
             <ProfileInfoBox
               title={

--- a/app/components/teacher/TeacherDetail/TeacherDetailMain.tsx
+++ b/app/components/teacher/TeacherDetail/TeacherDetailMain.tsx
@@ -41,17 +41,22 @@ export default function TeacherDetailMain() {
               }
             >
               <div className="flex flex-col gap-[14px]">
-                <ToggleBox
-                  title="학력"
-                  items={[
-                    `${data.data.university} ${data.data.major}`,
-                    data.data.highSchool,
-                  ]}
-                />
-                <ToggleBox
-                  title={`${subject === "english" ? "영어" : "수학"} 수업(${data.data.teachingHistory}년)`}
-                  items={data.data.teachingExperiences}
-                />
+                {data.data.highSchool && (
+                  <ToggleBox
+                    title="학력"
+                    items={[
+                      `${data.data.university} ${data.data.major}`,
+                      data.data.highSchool,
+                    ]}
+                  />
+                )}
+                {data.data.teachingExperiences &&
+                  data.data.teachingExperiences.length > 0 && (
+                    <ToggleBox
+                      title={`${subject === "english" ? "영어" : "수학"} 수업(${data.data.teachingHistory}년)`}
+                      items={data.data.teachingExperiences}
+                    />
+                  )}
                 {data.data.foreignExperiences &&
                   data.data.foreignExperiences.length > 0 && (
                     <ToggleBox

--- a/app/components/teacher/TeacherDetail/TeacherDetailRegionTime.tsx
+++ b/app/components/teacher/TeacherDetail/TeacherDetailRegionTime.tsx
@@ -27,17 +27,24 @@ export default function TeacherDetailRegionTime() {
           >
             <BulletList items={data.data.districts} />
           </ProfileInfoBox>
-          <ProfileInfoBox
-            title={
-              <p>
-                선생님이{" "}
-                <span className="text-primaryNormal">선호하는 시간</span>
-                이에요!
-              </p>
-            }
-          >
-            <BulletList items={formatAvailableTimes(data.data.availables)} />
-          </ProfileInfoBox>
+          {data.data.availables &&
+            !Object.values(data.data.availables).every(
+              (times) => times.length === 1 && times[0] === "불가",
+            ) && (
+              <ProfileInfoBox
+                title={
+                  <p>
+                    선생님이{" "}
+                    <span className="text-primaryNormal">선호하는 시간</span>
+                    이에요!
+                  </p>
+                }
+              >
+                <BulletList
+                  items={formatAvailableTimes(data.data.availables)}
+                />
+              </ProfileInfoBox>
+            )}
         </>
       )}
     </div>

--- a/app/hooks/query/useGetTutoringDetail.ts
+++ b/app/hooks/query/useGetTutoringDetail.ts
@@ -15,5 +15,6 @@ export function useGetTutoring({
     queryKey: ["tutoring"],
     queryFn: () => getTutoring({ teacherId, applcationFormId, phoneNumber }),
     staleTime: Infinity,
+    retry: 0,
   });
 }


### PR DESCRIPTION
## 🐈 PR 요약
> PR 내용 한 줄로 요약
- 관련 테크스펙 링크 : X
- 선생님 수락/보류 페이지 오류 처리
- 각종 null 처리 추가

## ✨ PR 상세
> PR 상세 내용 개조식으로 작성
- 선생님 수락/보류 페이지도 존재하지 않는 신청건인 경우 오류 페이지를 띄워주도록 수정함
- 기획 쪽에서 요구한 각종 null 처리(수업 경력, 해외 경험, 출신 고교, 수업 관리 방식, 가능시간)

## 🚨 참고사항
> 리뷰어들이 알아야 하거나 알면 좋은 참고사항 작성
- 이 부분 반영되면 16일에 할 전체 테크니컬 QA를 위해 develop을 main에 한번 올리겠습니다!

## 📸 스크린샷
> 화면 캡쳐 이미지
UI가 달라진 부분은 딱히 없습니다!

## ✅ 체크리스트
- [x] Reviewers 태그했나요?
- [x] Label 지정했나요?
- [x] 관련 테크스펙 링크 연결했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 오류 발생 시 대체 화면을 제공하여 사용자 경험을 보호하는 개선된 오류 처리 기능이 도입되었습니다.
- **버그 수정**
  - 교사 정보 페이지에서 관리 스타일, 학력, 경력 및 선호 시간 등의 섹션이 실제 데이터가 있을 때만 표시되어 불필요한 빈 영역이 제거되었습니다.
- **리팩터링**
  - 데이터 조회 시 자동 재시도 로직을 조정하여 오류를 보다 명확하게 인지할 수 있도록 개선하였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->