### PR TITLE
Fix/byunghoon qa : 어드민에서 선생님 프로필 상세보기로 가는 기능 추가, 링크에따른 사이드바 스타일 적용 방식 변경'

### DIFF
--- a/app/(route)/(admin)/zuzuclubadmin/[id]/page.tsx
+++ b/app/(route)/(admin)/zuzuclubadmin/[id]/page.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { Header } from "../../../../ui";
 import { Alim } from "../../../../components/admin/Alim";
 import ParentsRequest from "../../../../components/admin/ParentsRequest";

--- a/app/actions/get-acceptance/index.ts
+++ b/app/actions/get-acceptance/index.ts
@@ -21,6 +21,8 @@ const acceptanceSchema = z.object({
       classMatchingId: z.number(),
       name: z.string(),
       refuseReason: z.string().nullable(),
+      teacherId: z.number(),
+      subject: z.string(),
     }),
   ),
 });

--- a/app/components/admin/AlimColumn.tsx
+++ b/app/components/admin/AlimColumn.tsx
@@ -78,4 +78,25 @@ export const AlimTHeaderColumn = [
     header: "거절사유",
     size: 150,
   }),
+  columnHelper.display({
+    header: "프로필 상세보기",
+    cell: ({ row }) => {
+      const teacherId = row.original.teacherId;
+      const subject = row.original.subject;
+      const subjectParam =
+        subject === "영어" ? "english" : subject === "수학" ? "math" : subject;
+      const url = `/teacher/${teacherId}?subject=${subjectParam}`;
+
+      return (
+        <div className="flex w-[100px] flex-col">
+          <button
+            className="mb-1 rounded bg-blue-500 px-2 py-1 text-xs text-white hover:bg-blue-600"
+            onClick={() => window.open(url, "_blank")}
+          >
+            바로가기
+          </button>
+        </div>
+      );
+    },
+  }),
 ];

--- a/app/ui/Bar/Sidebar.tsx
+++ b/app/ui/Bar/Sidebar.tsx
@@ -2,28 +2,27 @@
 
 import Image from "next/image";
 import Link from "next/link";
-import { useSelectedLayoutSegment, useRouter } from "next/navigation";
+import {
+  useSelectedLayoutSegment,
+  usePathname,
+  useRouter,
+} from "next/navigation";
 
 import LogoImage from "../../../public/images/logo.png";
 import { useLogout } from "../../hooks/auth/useLogout";
 
 export function Sidebar() {
   const activeSegment = useSelectedLayoutSegment();
+  const pathname = usePathname();
   const router = useRouter();
   const { logout } = useLogout();
 
   const activeLinkClassName = "font-bold text-primary";
+  const isMatchingManagement = pathname.startsWith("/zuzuclubadmin");
 
-  const handleLogout = async () => {
-    try {
-      await logout();
-      // eslint-disable-next-line no-console
-      console.log("로그아웃 성공");
-      router.push("/zuzuclubadmin/login");
-    } catch (error) {
-      // eslint-disable-next-line no-console
-      console.error("로그아웃 실패:", error);
-    }
+  const handleLogout = () => {
+    logout();
+    router.push("/zuzuclubadmin/login");
   };
 
   return (
@@ -33,14 +32,14 @@ export function Sidebar() {
       role="navigation"
     >
       <div>
-        <Link href="/zuzuclubadmin" className="flex h-[100px] items-center p-2">
+        <Link href="/zuzuclubadmin" className="mt-5 flex items-center p-2">
           <Image src={LogoImage} height={36} width={36} alt="로고 이미지" />
           <span className="ml-2 text-lg font-bold text-headColor">Y-Edu</span>
         </Link>
         <div className="mt-4 flex flex-col gap-4 p-4">
           <Link
             href="/zuzuclubadmin"
-            className={activeSegment === null ? activeLinkClassName : ""}
+            className={isMatchingManagement ? activeLinkClassName : ""}
           >
             매칭관리
           </Link>

--- a/app/ui/Columns/TeacherColumns.tsx
+++ b/app/ui/Columns/TeacherColumns.tsx
@@ -49,6 +49,7 @@ export function getTeacherColumns({ handleOpenModal }: TeacherColumnsProps) {
                   onClick={() =>
                     window.open(
                       `/teacher/${teacher.teacherId}?subject=${subjectParam}`,
+                      "_blank",
                     )
                   }
                 >

--- a/app/ui/Columns/TeacherColumns.tsx
+++ b/app/ui/Columns/TeacherColumns.tsx
@@ -35,7 +35,30 @@ export function getTeacherColumns({ handleOpenModal }: TeacherColumnsProps) {
     columnHelper.accessor("nickName", { header: "닉네임" }),
     columnHelper.accessor("classTypes", {
       header: "과목",
-      cell: (props) => props.getValue().join(", ") || "-",
+      cell: ({ row, getValue }) => {
+        const teacher = row.original;
+        const subjects: Array<"수학" | "영어"> = getValue();
+        return (
+          <div className="flex flex-col">
+            {subjects.map((subject) => {
+              const subjectParam = subject === "수학" ? "math" : "english";
+              return (
+                <button
+                  key={subject}
+                  className="mb-1 rounded bg-blue-500 px-2 py-1 text-xs text-white hover:bg-blue-600"
+                  onClick={() =>
+                    window.open(
+                      `/teacher/${teacher.teacherId}?subject=${subjectParam}`,
+                    )
+                  }
+                >
+                  {subject}
+                </button>
+              );
+            })}
+          </div>
+        );
+      },
     }),
     columnHelper.accessor("name", { header: "본명" }),
     columnHelper.accessor("status", {


### PR DESCRIPTION
## 🐈 PR 요약
> PR 내용 한 줄로 요약
- 관련 테크스펙 링크 : QA

## ✨ PR 상세
> PR 상세 내용 개조식으로 작성

- 알림톡, 선생님리스트 테이블에 선생님 프로필 상세보기 버튼 추가.
- /zuzuclubadmin이하 모든 url에서 사이드바 매칭관리 active 디자인으로 변경.
- 로그아웃 함수에서 필요없는 console.log 제거

## 🚨 참고사항
> 리뷰어들이 알아야 하거나 알면 좋은 참고사항 작성

## 📸 스크린샷
> 화면 캡쳐 이미지
<img width="1421" alt="스크린샷 2025-02-20 오후 6 43 23" src="https://github.com/user-attachments/assets/a9dfe945-1578-4974-9b0f-9939e931f20d" />

## ✅ 체크리스트
- [x] Reviewers 태그했나요?
- [x] Label 지정했나요?
- [ ] 관련 테크스펙 링크 연결했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 관리 인터페이스에 “프로필 상세보기” 버튼이 추가되어, 강사 프로필의 세부 정보를 새 창에서 바로 확인할 수 있습니다.
  - 강사 목록의 과목 정보가 버튼 형태로 전환되어, 각 버튼 클릭 시 해당 강사 상세 페이지로 쉽게 이동할 수 있습니다.
  - 사이드바에서 활성 링크 표시와 로그아웃 처리가 개선되어, 사용자 경험이 더욱 향상되었습니다.
  - 수업 과목에 대한 새로운 데이터 속성이 추가되어, 응답에서 강사 ID와 과목 정보를 더 잘 반영합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->