### PR TITLE
Fix/byunghoon qa : 어드민 알림,선생님 리스트 테이블에 전화번호 컬럼 추가

### DIFF
--- a/app/actions/get-acceptance/index.ts
+++ b/app/actions/get-acceptance/index.ts
@@ -23,6 +23,7 @@ const acceptanceSchema = z.object({
       refuseReason: z.string().nullable(),
       teacherId: z.number(),
       subject: z.string(),
+      phoneNumber: z.string(),
     }),
   ),
 });

--- a/app/actions/get-teacher-detail/index.ts
+++ b/app/actions/get-teacher-detail/index.ts
@@ -13,7 +13,6 @@ export interface TeacherDetailsParams extends TeacherSimpleDetailsParams {
 
 export interface TeacherDetailsTeacherResponse {
   data: {
-    appealPoints: Array<string>;
     comment: string;
     introduce: string;
     teachingHistory: number;
@@ -26,14 +25,12 @@ export interface TeacherDetailsTeacherResponse {
     teachingStyleInfo1: string;
     teachingStyle2: string;
     teachingStyleInfo2: string;
-    recommendStudents: Array<string>;
   };
 }
 
 export interface TeacherDetailsClassResponse {
   data: {
     teachingStyle: string;
-    managementStyle: string;
     video?: string;
   };
 }

--- a/app/actions/get-teacher-search/index.ts
+++ b/app/actions/get-teacher-search/index.ts
@@ -19,6 +19,7 @@ export interface FilteringTeacher {
   university: string;
   major: string;
   districts: string[];
+  phoneNumber: string;
   video: string;
   issue: string | null;
 }

--- a/app/actions/get-teacher-search/index.ts
+++ b/app/actions/get-teacher-search/index.ts
@@ -11,9 +11,9 @@ export interface TeacherSearchParams {
 export interface FilteringTeacher {
   teacherId: string;
   nickName: string;
-  classTypes: Array<"수학" | "영어">;
+  classTypes: Array<string>;
   name: string;
-  status: "등록중" | "활동중" | "일시정지" | "종료";
+  status: string;
   accept: number;
   total: number;
   university: string;

--- a/app/components/admin/AlimColumn.tsx
+++ b/app/components/admin/AlimColumn.tsx
@@ -70,6 +70,10 @@ export const AlimTHeaderColumn = [
     header: "본명",
     size: 80,
   }),
+  columnHelper.accessor("phoneNumber", {
+    header: "전화번호",
+    size: 80,
+  }),
   columnHelper.accessor("receiveAcceptance", {
     header: "답변율",
     size: 80,
@@ -88,7 +92,7 @@ export const AlimTHeaderColumn = [
       const url = `/teacher/${teacherId}?subject=${subjectParam}`;
 
       return (
-        <div className="flex w-[100px] flex-col">
+        <div className="flex w-[80px] flex-col">
           <button
             className="mb-1 rounded bg-blue-500 px-2 py-1 text-xs text-white hover:bg-blue-600"
             onClick={() => window.open(url, "_blank")}

--- a/app/components/teacher/TeacherDetail/TeacherDetailClass.tsx
+++ b/app/components/teacher/TeacherDetail/TeacherDetailClass.tsx
@@ -34,21 +34,7 @@ export default function TeacherDetailClass() {
           >
             {data.data.teachingStyle}
           </ProfileInfoBox>
-          {data.data.managementStyle && (
-            <ProfileInfoBox
-              title={
-                <p className="whitespace-pre-line">
-                  {subject === "english" ? "영어" : "수학"} 역량을 키울 수
-                  있도록
-                  {"\n"}
-                  <span className="text-primaryNormal">학생 관리</span>는 이렇게
-                  해요!
-                </p>
-              }
-            >
-              {data.data.managementStyle}
-            </ProfileInfoBox>
-          )}
+
           {data.data.video && (
             <ProfileInfoBox
               title={

--- a/app/components/teacher/TeacherDetail/TeacherDetailMain.tsx
+++ b/app/components/teacher/TeacherDetail/TeacherDetailMain.tsx
@@ -2,8 +2,6 @@
 import { useParams, useSearchParams } from "next/navigation";
 
 import { TEACHER_STYLE_ICON } from "app/constants/teacherStyle";
-import BulletList from "app/ui/List/BulletList";
-import DividerList from "app/ui/List/DividerList";
 import ToggleBox from "app/ui/ToggleBox";
 import IconTitleChip from "app/components/teacher/IconTitleChip";
 import ProfileInfoBox from "app/components/teacher/ProfileInfoBox";
@@ -25,91 +23,84 @@ export default function TeacherDetailMain() {
   return (
     <div className="w-full">
       {data && (
-        <>
-          <DividerList textList={data.data.appealPoints} />
-          <div className="flex flex-col gap-[10px] bg-primaryPale">
-            <ProfileInfoBox title={data.data.comment}>
-              {data.data.introduce}
-            </ProfileInfoBox>
-            <ProfileInfoBox
-              title={
-                <p>
-                  선생님의{" "}
-                  <span className="text-primaryNormal">경력과 경험</span>
-                  이에요.
-                </p>
-              }
-            >
-              <div className="flex flex-col gap-[14px]">
-                {data.data.highSchool && (
+        <div className="flex flex-col gap-[10px] bg-primaryPale">
+          <ProfileInfoBox title={data.data.comment}>
+            {data.data.introduce}
+          </ProfileInfoBox>
+          <ProfileInfoBox
+            title={
+              <p className="mb-[20px]">
+                선생님의 <span className="text-primaryNormal">경력과 경험</span>
+                이에요.
+              </p>
+            }
+          >
+            <div className="flex flex-col gap-[14px]">
+              {data.data.highSchool && (
+                <ToggleBox
+                  title="학력"
+                  items={[
+                    `${data.data.university} ${data.data.major}`,
+                    data.data.highSchool,
+                  ]}
+                />
+              )}
+              {data.data.teachingExperiences &&
+                data.data.teachingExperiences.length > 0 && (
                   <ToggleBox
-                    title="학력"
-                    items={[
-                      `${data.data.university} ${data.data.major}`,
-                      data.data.highSchool,
-                    ]}
+                    title={`${subject === "english" ? "영어" : "수학"} 수업(${data.data.teachingHistory}년)`}
+                    items={data.data.teachingExperiences}
                   />
                 )}
-                {data.data.teachingExperiences &&
-                  data.data.teachingExperiences.length > 0 && (
-                    <ToggleBox
-                      title={`${subject === "english" ? "영어" : "수학"} 수업(${data.data.teachingHistory}년)`}
-                      items={data.data.teachingExperiences}
-                    />
-                  )}
-                {data.data.foreignExperiences &&
-                  data.data.foreignExperiences.length > 0 && (
-                    <ToggleBox
-                      title="해외 경험"
-                      items={data.data.foreignExperiences}
-                    />
-                  )}
-              </div>
-            </ProfileInfoBox>
-            <ProfileInfoBox
-              title={
-                <p>
-                  이런 <span className="text-primaryNormal">스타일</span>의
-                  선생님이에요.
+              {data.data.foreignExperiences &&
+                data.data.foreignExperiences.length > 0 && (
+                  <ToggleBox
+                    title="해외 경험"
+                    items={data.data.foreignExperiences}
+                  />
+                )}
+            </div>
+          </ProfileInfoBox>
+          <ProfileInfoBox
+            title={
+              <p>
+                이런 <span className="text-primaryNormal">스타일</span>의
+                선생님이에요.
+              </p>
+            }
+          >
+            <div className="flex flex-col gap-[22px]">
+              <div className="mt-[18px] flex flex-col gap-[12px]">
+                <IconTitleChip
+                  title={data.data.teachingStyle1}
+                  icon={
+                    TEACHER_STYLE_ICON[
+                      data.data
+                        .teachingStyle1 as keyof typeof TEACHER_STYLE_ICON
+                    ]
+                  }
+                />
+                <p className="text-[15px] leading-[156%] tracking-[-0.02em] text-labelNormal">
+                  {data.data.teachingStyleInfo1}
                 </p>
-              }
-            >
-              <div className="flex flex-col gap-[22px]">
-                <div className="flex flex-col gap-[12px]">
-                  <IconTitleChip
-                    title={data.data.teachingStyle1}
-                    icon={
-                      TEACHER_STYLE_ICON[
-                        data.data
-                          .teachingStyle1 as keyof typeof TEACHER_STYLE_ICON
-                      ]
-                    }
-                  />
-                  <p className="text-[15px] leading-[156%] tracking-[-0.02em] text-labelNormal">
-                    {data.data.teachingStyleInfo1}
-                  </p>
-                </div>
-                <div className="flex flex-col gap-[12px]">
-                  <IconTitleChip
-                    title={data.data.teachingStyle2}
-                    icon={
-                      TEACHER_STYLE_ICON[
-                        data.data
-                          .teachingStyle2 as keyof typeof TEACHER_STYLE_ICON
-                      ]
-                    }
-                  />
-                  <p className="text-[15px] leading-[156%] tracking-[-0.02em] text-labelNormal">
-                    {data.data.teachingStyleInfo2}
-                  </p>
-                </div>
               </div>
-            </ProfileInfoBox>
-            <ProfileInfoBox title="이런 학생에게 잘 맞아요!">
-              <BulletList items={data.data.recommendStudents} />
-            </ProfileInfoBox>
-          </div>
-        </>
+              <div className="flex flex-col gap-[12px]">
+                <IconTitleChip
+                  title={data.data.teachingStyle2}
+                  icon={
+                    TEACHER_STYLE_ICON[
+                      data.data
+                        .teachingStyle2 as keyof typeof TEACHER_STYLE_ICON
+                    ]
+                  }
+                />
+                <p className="text-[15px] leading-[156%] tracking-[-0.02em] text-labelNormal">
+                  {data.data.teachingStyleInfo2}
+                </p>
+              </div>
+            </div>
+          </ProfileInfoBox>
+        </div>
       )}
     </div>
   );

--- a/app/ui/Columns/TeacherColumns.tsx
+++ b/app/ui/Columns/TeacherColumns.tsx
@@ -37,7 +37,7 @@ export function getTeacherColumns({ handleOpenModal }: TeacherColumnsProps) {
       header: "과목",
       cell: ({ row, getValue }) => {
         const teacher = row.original;
-        const subjects: Array<"수학" | "영어"> = getValue();
+        const subjects = getValue();
         return (
           <div className="flex flex-col">
             {subjects.map((subject) => {
@@ -62,6 +62,9 @@ export function getTeacherColumns({ handleOpenModal }: TeacherColumnsProps) {
       },
     }),
     columnHelper.accessor("name", { header: "본명" }),
+    columnHelper.accessor("phoneNumber", {
+      header: "전화번호",
+    }),
     columnHelper.accessor("status", {
       header: "활동상태",
       cell: ({ getValue }) => getValue(),
@@ -81,9 +84,9 @@ export function getTeacherColumns({ handleOpenModal }: TeacherColumnsProps) {
         cell: (info) => {
           const { university, major } = info.getValue();
           return (
-            <div>
-              <div>{university}</div>
-              <div>{major}</div>
+            <div className="max-w-[120px] break-words">
+              {university}&nbsp;
+              {major}
             </div>
           );
         },


### PR DESCRIPTION
## 🐈 PR 요약
> PR 내용 한 줄로 요약
- 관련 테크스펙 링크 : x

## ✨ PR 상세
> PR 상세 내용 개조식으로 작성

- 알림톡 테이블 / 선생님 리스트 테이블에 전화번호 항목 추가
- 추후 확장성을 위해 타입 조정했습니다.

## 🚨 참고사항
> 리뷰어들이 알아야 하거나 알면 좋은 참고사항 작성

## 📸 스크린샷
> 화면 캡쳐 이미지

<img width="1250" alt="스크린샷 2025-02-25 오후 2 11 35" src="https://github.com/user-attachments/assets/3dfdd3eb-fed5-4513-a9a2-f55f7c532446" />
<img width="1247" alt="스크린샷 2025-02-25 오후 2 11 41" src="https://github.com/user-attachments/assets/d1632d04-7f38-432d-ab74-d088c6cde7a9" />


## ✅ 체크리스트
- [x] Reviewers 태그했나요?
- [x] Label 지정했나요?
- [ ] 관련 테크스펙 링크 연결했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- 관리자 및 교사 목록에 전화번호 정보가 추가되어, 연락처를 한눈에 확인할 수 있습니다.
	- 학부모 요청 화면이 업데이트되어, 어린이 레벨 대신 "알게된 경로" 정보가 제공되고 불필요한 선생님 스타일 정보가 간소화되었습니다.
	- 교사 검색 결과의 정보 배치가 개선되어, 대학 및 전공 정보의 표현 방식이 보다 명확해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->