### PR TITLE
fix: 알림테이블 프로필 상세보기 컬럼에서 버튼 외 영역 클릭 시 해당 행 체크되지 않도록 수정

### DIFF
--- a/app/components/admin/AlimColumn.tsx
+++ b/app/components/admin/AlimColumn.tsx
@@ -92,10 +92,13 @@ export const AlimTHeaderColumn = [
       const url = `/teacher/${teacherId}?subject=${subjectParam}`;
 
       return (
-        <div className="flex w-[80px] flex-col">
+        <div className="flex cursor-default items-center space-x-2 p-4">
           <button
             className="mb-1 rounded bg-blue-500 px-2 py-1 text-xs text-white hover:bg-blue-600"
-            onClick={() => window.open(url, "_blank")}
+            onClick={(e) => {
+              e.stopPropagation();
+              window.open(url, "_blank");
+            }}
           >
             바로가기
           </button>

--- a/app/components/admin/AlimTable.tsx
+++ b/app/components/admin/AlimTable.tsx
@@ -55,7 +55,14 @@ export function AlimTable() {
                   }}
                 >
                   {row.getVisibleCells().map((cell) => (
-                    <td key={cell.id} className="p-4 text-left text-sm">
+                    <td
+                      key={cell.id}
+                      className={`text-left text-sm ${
+                        cell.column.columnDef.header === "프로필 상세보기"
+                          ? ""
+                          : "p-4"
+                      }`}
+                    >
                       {flexRender(
                         cell.column.columnDef.cell,
                         cell.getContext(),


### PR DESCRIPTION
## 🐈 PR 요약
> PR 내용 한 줄로 요약
- 관련 테크스펙 링크 : x

## ✨ PR 상세
> PR 상세 내용 개조식으로 작성

-알림톡 테이블 선생님 프로필 상세보기 영역에서 버튼 외 컬럼 영역을 클릭해도 해당 행이 선택되지 않도록 수정했습니다.

## 🚨 참고사항
> 리뷰어들이 알아야 하거나 알면 좋은 참고사항 작성

- 패딩이 전체 컬럼에 먹여져 있어서 클릭이벤트 조절이 안되는 문제가 있었습니다. 
- 이를 해결하기 위해 조건문 사용으로 패딩을 "상세프로필보기" 컬럼영역에서 별도로 부여하도록 수정했습니다.

## 📸 스크린샷
> 화면 캡쳐 이미지

## ✅ 체크리스트
- [x] Reviewers 태그했나요?
- [x] Label 지정했나요?
- [ ] 관련 테크스펙 링크 연결했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **스타일**
	- 관리 인터페이스의 레이아웃과 디자인이 개선되어, 일부 테이블 셀에 조건부 패딩이 적용됩니다.
- **리팩터**
	- 버튼 클릭 이벤트 처리 로직을 개선하여 불필요한 이벤트 전파를 방지하고, 링크가 새 탭에서 안정적으로 열리도록 최적화하였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->