### PR TITLE
fix : 어드민에서 알림톡 상태에 따라 정렬하는 구문 추가

### DIFF
--- a/app/(route)/(admin)/zuzuclubadmin/[id]/(hooks)/useAlimTable.tsx
+++ b/app/(route)/(admin)/zuzuclubadmin/[id]/(hooks)/useAlimTable.tsx
@@ -37,6 +37,13 @@ export const AlimTableProvider = ({
 
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
 
+  const statusOrder = {
+    전송: 1,
+    수락: 2,
+    대기: 3,
+    거절: 4,
+  };
+
   const alimData = useMemo<
     (AcceptanceSchema["alarmTalkResponses"][0] & {
       receiveAcceptance: string;
@@ -54,7 +61,9 @@ export const AlimTableProvider = ({
 
   const alimTable = useReactTable({
     columns: AlimTHeaderColumn,
-    data: alimData,
+    data: alimData.sort((a, b) => {
+      return (statusOrder[a.status] || 0) - (statusOrder[b.status] || 0);
+    }),
     getCoreRowModel: getCoreRowModel(),
     onRowSelectionChange: setRowSelection,
     state: {

--- a/app/components/admin/AlimColumn.tsx
+++ b/app/components/admin/AlimColumn.tsx
@@ -61,6 +61,7 @@ export const AlimTHeaderColumn = [
           return <span className="text-[#C00D0D]">거절</span>;
       }
     },
+    enableSorting: true,
   }),
   columnHelper.accessor("nickName", {
     header: "영어이름",


### PR DESCRIPTION
## 🐈 PR 요약
> PR 내용 한 줄로 요약
- 관련 테크스펙 링크 : X

## ✨ PR 상세
> PR 상세 내용 개조식으로 작성
- 어드민에서 알림톡 상태에 따라 전송 - 수락 - 대기 - 거절 순으로 정렬해주었어요!

## 🚨 참고사항
> 리뷰어들이 알아야 하거나 알면 좋은 참고사항 작성

## 📸 스크린샷
> 화면 캡쳐 이미지

## ✅ 체크리스트
- [x] Reviewers 태그했나요?
- [x] Label 지정했나요?
- [ ] 관련 테크스펙 링크 연결했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 테이블 데이터가 상태 값에 따라 정렬되도록 개선되었습니다.
  - 상태 열에 정렬 옵션이 활성화되어, 사용자 편의성이 강화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->