### PR TITLE
fix : 알림톡 발송 분을 일 + 시간 + 분으로 포맷하는 함수 구현

### DIFF
--- a/app/components/admin/AlimHeader.tsx
+++ b/app/components/admin/AlimHeader.tsx
@@ -11,6 +11,7 @@ import { usePostMatchingAcceptance } from "@/hooks/mutation";
 import { useModal } from "@/hooks/custom";
 import { Modal } from "@/ui";
 import { useAlimTableContext } from "@/(route)/(admin)/zuzuclubadmin/[id]/(hooks)/useAlimTable";
+import { formatTimetoDate } from "@/utils/formatTimetoDate";
 
 interface AlimHeaderProps {
   matchingId: string;
@@ -70,7 +71,7 @@ export function AlimHeader({ matchingId }: AlimHeaderProps) {
             {`(${alimData.accept} / ${alimData.total})`}
           </span>
           <span className="tex-sm ml-8 font-medium" suppressHydrationWarning>
-            발송 후 {alimData.time}분 경과
+            발송 후 {formatTimetoDate(alimData.time)} 경과
           </span>
         </div>
         <button

--- a/app/utils/formatTimetoDate.ts
+++ b/app/utils/formatTimetoDate.ts
@@ -1,0 +1,7 @@
+export const formatTimetoDate = (timeAmount: number) => {
+  const days = Math.floor(timeAmount / (60 * 24));
+  const hours = Math.floor((timeAmount % (60 * 24)) / 60);
+  const minutes = timeAmount % 60;
+
+  return `${days}일 ${hours}시간 ${minutes}분`;
+};


### PR DESCRIPTION
## 🐈 PR 요약
> PR 내용 한 줄로 요약
- 관련 테크스펙 링크 : X

## ✨ PR 상세
> PR 상세 내용 개조식으로 작성

- 알림톡 발송 경과 분을 일 + 시간 + 분으로 포맷팅해주었습니다.

## 🚨 참고사항
> 리뷰어들이 알아야 하거나 알면 좋은 참고사항 작성

## 📸 스크린샷
> 화면 캡쳐 이미지

<img width="508" alt="image" src="https://github.com/user-attachments/assets/1358afe8-c280-4165-91d0-00b0fb9ff1b3" />


## ✅ 체크리스트
- [x] Reviewers 태그했나요?
- [x] Label 지정했나요?
- [ ] 관련 테크스펙 링크 연결했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - 알림 발송 후 경과 시간이 기존의 단순한 분 단위 표시에서, 일/시간/분 형식으로 개선되어 보다 직관적인 정보를 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->