### PR TITLE
fix: 테이블 반응형으로 줄지 않고 스크롤되도록 변경

### DIFF
--- a/app/(route)/(admin)/zuzuclubadmin/[id]/page.tsx
+++ b/app/(route)/(admin)/zuzuclubadmin/[id]/page.tsx
@@ -13,7 +13,7 @@ export default function MatchingDetailHome({
   const { id } = params;
 
   return (
-    <div className="flex flex-col">
+    <div className="flex min-w-[1200px] flex-col overflow-x-auto">
       <Header matchingId={id} />
       <Alim id={id} />
       <ParentsRequest applicationFormId={id} />

--- a/app/ui/Bar/Sidebar.tsx
+++ b/app/ui/Bar/Sidebar.tsx
@@ -30,7 +30,7 @@ export function Sidebar() {
 
   return (
     <nav
-      className="fixed left-0 top-0 flex h-screen w-[180px] flex-col justify-between border-r border-[#E6EFF5] bg-white pl-2 text-disabled"
+      className="fixed left-0 top-0 z-50 flex h-screen w-[180px] flex-col justify-between border-r border-[#E6EFF5] bg-white pl-2 text-disabled"
       aria-label="메인 네비게이션"
       role="navigation"
     >


### PR DESCRIPTION
## 🐈 PR 요약
> PR 내용 한 줄로 요약
- 관련 테크스펙 링크 : x

## ✨ PR 상세
> PR 상세 내용 개조식으로 작성

-어드민에서 테이블이 반응형으로 줄어듦에 따라 텍스트 깨짐이 있어
전체 페이지 넓이를 고정하고, 스크롤되도록 했습니다.

## 🚨 참고사항
> 리뷰어들이 알아야 하거나 알면 좋은 참고사항 작성


## 📸 스크린샷
> 화면 캡쳐 이미지

## ✅ 체크리스트
- [ x] Reviewers 태그했나요?
- [ x] Label 지정했나요?
- [ ] 관련 테크스펙 링크 연결했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **스타일**
  - 관리자 상세 화면에서 최소 너비(1200px)가 적용되고, 가로 스크롤이 활성화되어 레이아웃이 개선되었습니다.
  - 측면 네비게이션의 계층 우선순위가 상향되어 다른 요소 위에 표시되도록 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->