### PR TITLE
feat: 과외건 공지 받기 토글 끌 때 모달창 추가

### DIFF
--- a/app/components/teacher/MatchingModal.tsx
+++ b/app/components/teacher/MatchingModal.tsx
@@ -47,7 +47,7 @@ export function MatchingModal({ isOpen, ...rest }: MatchingModalProps) {
       : "bg-[#B8B8B8] text-white";
 
   return (
-    <div className="bg-opacity / 36 bg-opacity/50 fixed inset-0 z-10 flex items-center justify-center bg-black">
+    <div className="fixed inset-0 z-10 flex items-center justify-center bg-black/50">
       <div
         ref={matchingModalRef}
         className={`flex ${modalHeight} w-[335px] flex-col justify-center gap-[6px] rounded-[14px] bg-white p-[24px] align-middle`}

--- a/app/components/teacher/MatchingModal.tsx
+++ b/app/components/teacher/MatchingModal.tsx
@@ -47,7 +47,7 @@ export function MatchingModal({ isOpen, ...rest }: MatchingModalProps) {
       : "bg-[#B8B8B8] text-white";
 
   return (
-    <div className="bg-opacity / 36 fixed inset-0 z-10 flex items-center justify-center bg-black bg-opacity-50">
+    <div className="bg-opacity / 36 bg-opacity/50 fixed inset-0 z-10 flex items-center justify-center bg-black">
       <div
         ref={matchingModalRef}
         className={`flex ${modalHeight} w-[335px] flex-col justify-center gap-[6px] rounded-[14px] bg-white p-[24px] align-middle`}

--- a/app/components/teacher/TeacherSetting/TeacherSettingMain.tsx
+++ b/app/components/teacher/TeacherSetting/TeacherSettingMain.tsx
@@ -9,12 +9,14 @@ import SettingBox from "@/ui/Box/SettingBox";
 import { useGetTeacherSettingInfo } from "@/hooks/query/useGetTeacherSettingInfo";
 import { usePatchTeacherSettingAlarmTalk } from "@/hooks/mutation/usePatchTeacherSettingAlarmTalk";
 import { formatAvailableTimes } from "@/utils/formatAvailableTimes";
+import { Modal } from "@/ui/Modal";
 
 export default function TeacherSettingMain() {
   const router = useRouter();
   const [isToggled, setIsToggled] = useState(false);
   const [teacherName, setTeacherName] = useState("");
   const [teacherPhone, setTeacherPhone] = useState("");
+  const [showModal, setShowModal] = useState(false);
 
   useEffect(() => {
     const storedName = localStorage.getItem("teacherName") || "";
@@ -53,12 +55,16 @@ export default function TeacherSettingMain() {
 
   const handleToggleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const newValue = event.target.checked;
-    setIsToggled(newValue);
-    patchAlarmTalk({
-      name: teacherName,
-      phoneNumber: teacherPhone,
-      alarmTalk: newValue,
-    });
+    if (!newValue) {
+      setShowModal(true);
+    } else {
+      setIsToggled(true);
+      patchAlarmTalk({
+        name: teacherName,
+        phoneNumber: teacherPhone,
+        alarmTalk: true,
+      });
+    }
   };
 
   const chunkArray = (arr: string[], size: number) =>
@@ -71,12 +77,32 @@ export default function TeacherSettingMain() {
 
   return (
     <div>
+      <Modal
+        isOpen={showModal}
+        title="과외건 공지를 받지 않겠습니까?"
+        message="이 설정을 끄면 지역에 맞는 과외건 공지 메세지가 전송되지 않습니다."
+        confirmText="받지 않기"
+        cancelText="계속 받기"
+        handleOnConfirm={() => {
+          setIsToggled(false);
+          patchAlarmTalk({
+            name: teacherName,
+            phoneNumber: teacherPhone,
+            alarmTalk: false,
+          });
+          setShowModal(false);
+        }}
+        handleOnCancel={() => {
+          setIsToggled(true);
+          setShowModal(false);
+        }}
+      />
       <p className="border-b border-primaryPale pb-5 pt-10 text-center font-pretendard text-xl font-bold text-labelStrong">
         {data.name} 선생님 과외 설정
       </p>
       <div className="flex flex-col gap-[2px] bg-primaryPale">
         <SettingBox
-          title="활동상태"
+          title="과외건 공지 받기"
           isToggle
           toggleChecked={isToggled}
           onToggleChange={handleToggleChange}

--- a/app/ui/Modal.tsx
+++ b/app/ui/Modal.tsx
@@ -28,8 +28,11 @@ export function Modal({
   }
 
   return (
-    <div className="fixed inset-0 z-10 flex items-center justify-center bg-black bg-opacity-50">
-      <div ref={modalRef} className="w-1/3 rounded-lg bg-white p-6 shadow-lg">
+    <div className="fixed inset-0 z-10 flex items-center justify-center bg-black/50">
+      <div
+        ref={modalRef}
+        className="w-1/3 min-w-[335px] rounded-lg bg-white p-6 shadow-lg"
+      >
         <h2 className="mb-4 text-lg font-bold">{title}</h2>
         <p className="mb-6">{message}</p>
         <div className="flex justify-end">


### PR DESCRIPTION
## 🐈 PR 요약
> PR 내용 한 줄로 요약
- 관련 테크스펙 링크 : https://www.notion.so/Y-Edu-ca553c96e3474917827bcd34f1e1e9bb?pvs=4

## ✨ PR 상세
> PR 상세 내용 개조식으로 작성

-과외건 공지 토글을 끌 때, 실수를 방지하기 위해 확인 모달창을 추가했습니다.

## 🚨 참고사항
> 리뷰어들이 알아야 하거나 알면 좋은 참고사항 작성

- tailwindcss v3에서 bg-opacity-50 이 형식이 > bg-black/50 이렇게 바뀌었대요!

## 📸 스크린샷
> 화면 캡쳐 이미지

<img width="659" alt="스크린샷 2025-03-14 오후 4 44 40" src="https://github.com/user-attachments/assets/6d5323aa-9e67-4358-9d17-c3fa436ba0a2" />

## ✅ 체크리스트
- [x] Reviewers 태그했나요?
- [x] Label 지정했나요?
- [x] 관련 테크스펙 링크 연결했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **새로운 기능**
	- 알람 토크 설정 토글 시, 사용자가 off로 전환할 때 확인 모달이 표시되어 추가 확인 과정을 도입했습니다.
- **스타일**
	- 모달의 배경 불투명도 스타일이 개선되었습니다.
	- 공통 모달 레이아웃에 최소 너비가 적용되어 UI가 향상되었습니다.
	- 토글 제목이 "활동상태"에서 "과외건 공지 받기"로 변경되어 사용자 인터페이스가 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->