### PR TITLE
fix: 초기 렌더링 시 data가 없을 때 Error페이지 렌더링 되는 문제 해결

### DIFF
--- a/app/components/teacher/TeacherSetting/TeacherSettingMain.tsx
+++ b/app/components/teacher/TeacherSetting/TeacherSettingMain.tsx
@@ -9,6 +9,7 @@ import SettingBox from "@/ui/Box/SettingBox";
 import { useGetTeacherSettingInfo } from "@/hooks/query/useGetTeacherSettingInfo";
 import { usePatchTeacherSettingAlarmTalk } from "@/hooks/mutation/usePatchTeacherSettingAlarmTalk";
 import { Modal } from "@/ui/Modal";
+import ErrorUI from "@/ui/ErrorUI";
 
 export default function TeacherSettingMain() {
   const router = useRouter();
@@ -31,10 +32,16 @@ export default function TeacherSettingMain() {
     setTeacherPhone(storedPhone);
   }, [router]);
 
-  const { data, isLoading } = useGetTeacherSettingInfo({
-    name: teacherName,
-    phoneNumber: teacherPhone,
-  });
+  const isQueryEnabled = Boolean(teacherName && teacherPhone);
+  const { data, isLoading, isError } = useGetTeacherSettingInfo(
+    {
+      name: teacherName,
+      phoneNumber: teacherPhone,
+    },
+    {
+      enabled: isQueryEnabled,
+    },
+  );
 
   const { mutate: patchAlarmTalk } = usePatchTeacherSettingAlarmTalk();
 
@@ -44,13 +51,21 @@ export default function TeacherSettingMain() {
     }
   }, [data]);
 
-  if (isLoading)
+  if (!isQueryEnabled) {
+    return null;
+  }
+
+  if (isLoading) {
     return (
       <div className="flex min-h-screen items-center justify-center">
         <CircularProgress />
       </div>
     );
-  if (!data) return <div>Error occurred</div>;
+  }
+
+  if (isError || !data) {
+    return <ErrorUI />;
+  }
 
   const handleToggleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const newValue = event.target.checked;

--- a/app/components/teacher/TeacherSetting/TeacherSettingProvider.tsx
+++ b/app/components/teacher/TeacherSetting/TeacherSettingProvider.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { useEffect, useState, ReactNode } from "react";
+import { useRouter } from "next/navigation";
+import CircularProgress from "@mui/material/CircularProgress";
+
+import type { TeacherSettingInfoResponse } from "@/actions/get-teacher-setting-info";
+import { useGetTeacherSettingInfo } from "@/hooks/query/useGetTeacherSettingInfo";
+import ErrorUI from "@/ui/ErrorUI";
+
+interface TeacherSettingProviderProps {
+  children: (
+    data: TeacherSettingInfoResponse,
+    teacherName: string,
+    teacherPhone: string,
+  ) => ReactNode;
+}
+
+export default function TeacherSettingProvider({
+  children,
+}: TeacherSettingProviderProps) {
+  const router = useRouter();
+  const [teacherName, setTeacherName] = useState<string | null>(null);
+  const [teacherPhone, setTeacherPhone] = useState<string | null>(null);
+
+  useEffect(() => {
+    const storedName = localStorage.getItem("teacherName");
+    const storedPhone = localStorage.getItem("teacherPhone");
+
+    if (!storedName || !storedPhone) {
+      alert("로그인하세요");
+      router.push("/teachersetting/login");
+      return;
+    }
+    setTeacherName(storedName);
+    setTeacherPhone(storedPhone);
+  }, [router]);
+
+  const isQueryEnabled = Boolean(teacherName && teacherPhone);
+
+  const { data, isLoading, isError } = useGetTeacherSettingInfo(
+    {
+      name: teacherName ?? "",
+      phoneNumber: teacherPhone ?? "",
+    },
+    {
+      enabled: isQueryEnabled,
+    },
+  );
+
+  if (!isQueryEnabled || isLoading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <CircularProgress />
+      </div>
+    );
+  }
+
+  if (isError || !data) {
+    return <ErrorUI />;
+  }
+
+  return <>{children(data, teacherName as string, teacherPhone as string)}</>;
+}

--- a/app/components/teacher/TeacherSetting/TeacherSettingRegion.tsx
+++ b/app/components/teacher/TeacherSetting/TeacherSettingRegion.tsx
@@ -41,10 +41,16 @@ export default function TeacherSettingRegion() {
     setTeacherPhone(storedPhone);
   }, [router]);
 
-  const { data, isLoading } = useGetTeacherSettingInfo({
-    name: teacherName,
-    phoneNumber: teacherPhone,
-  });
+  const isQueryEnabled = Boolean(teacherName && teacherPhone);
+  const { data, isLoading, isError } = useGetTeacherSettingInfo(
+    {
+      name: teacherName,
+      phoneNumber: teacherPhone,
+    },
+    {
+      enabled: isQueryEnabled,
+    },
+  );
 
   const { mutate: patchRegion, isPending: patchLoading } =
     usePatchTeacherSettingRegion();
@@ -88,16 +94,7 @@ export default function TeacherSettingRegion() {
     () => !arraysEqual(activeButtons, initialActive),
     [activeButtons, initialActive],
   );
-
   useUnsavedChangeWarning(hasChanges);
-
-  if (isLoading)
-    return (
-      <div className="flex min-h-screen items-center justify-center">
-        <CircularProgress />
-      </div>
-    );
-  if (!data) return <ErrorUI />;
 
   const handleBackClick = () => {
     if (hasChanges) {
@@ -130,6 +127,22 @@ export default function TeacherSettingRegion() {
       );
     }
   };
+
+  if (!isQueryEnabled) {
+    return null;
+  }
+
+  if (isLoading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <CircularProgress />
+      </div>
+    );
+  }
+
+  if (isError || !data) {
+    return <ErrorUI />;
+  }
 
   return (
     <div>

--- a/app/components/teacher/TeacherSetting/TeacherSettingTime.tsx
+++ b/app/components/teacher/TeacherSetting/TeacherSettingTime.tsx
@@ -33,10 +33,16 @@ export function SettingTeacherTime() {
     setTeacherPhone(storedPhone);
   }, [router]);
 
-  const { data, isLoading } = useGetTeacherSettingInfo({
-    name: teacherName,
-    phoneNumber: teacherPhone,
-  });
+  const isQueryEnabled = Boolean(teacherName && teacherPhone);
+  const { data, isLoading, isError } = useGetTeacherSettingInfo(
+    {
+      name: teacherName,
+      phoneNumber: teacherPhone,
+    },
+    {
+      enabled: isQueryEnabled,
+    },
+  );
 
   const handleBackClick = () => {
     if (hasChanges) {
@@ -50,13 +56,21 @@ export function SettingTeacherTime() {
     }
   };
 
-  if (isLoading)
+  if (!isQueryEnabled) {
+    return null;
+  }
+
+  if (isLoading) {
     return (
       <div className="flex min-h-screen items-center justify-center">
         <CircularProgress />
       </div>
     );
-  if (!data) return <ErrorUI />;
+  }
+
+  if (isError || !data) {
+    return <ErrorUI />;
+  }
 
   return (
     <div>


### PR DESCRIPTION
## 🐈 PR 요약
> PR 내용 한 줄로 요약
- 관련 테크스펙 링크 : -

## ✨ PR 상세
> PR 상세 내용 개조식으로 작성

- 초기 렌더링 시 data 없어 Error페이지 렌더링 되는 문제 해결.

## 🚨 참고사항
> 리뷰어들이 알아야 하거나 알면 좋은 참고사항 작성

중복되는 코드를 일단 provider 파일로 분리했는데 적용은 추후 리팩토링 작업 때 하겠습니다!

## 📸 스크린샷
> 화면 캡쳐 이미지

## ✅ 체크리스트
- [x] Reviewers 태그했나요?
- [x] Label 지정했나요?
- [x] 관련 테크스펙 링크 연결했나요?
