### PR TITLE
Feat/add schedule result : 학부모 매칭 리스트 및 요청사항 탭에 상담 결과 수업 요일,시간 추가

### DIFF
--- a/app/actions/get-parents-list/index.ts
+++ b/app/actions/get-parents-list/index.ts
@@ -1,10 +1,17 @@
 import { httpService } from "app/utils/httpService";
 
+export interface ScheduledClass {
+  day: string;
+  startTime: string;
+  classTime: number;
+}
+
 export interface ParentsListResponse {
   applicationFormId: string;
   kakaoName: string | null;
   classCount: string;
   classTime: string;
+  scheduledClasses?: ScheduledClass[];
   pay: number;
   wantedSubject: string;
   source: string;

--- a/app/actions/get-parents-request/index.ts
+++ b/app/actions/get-parents-request/index.ts
@@ -17,6 +17,15 @@ const parentsRequestSchema = z.object({
   goals: z.array(z.string()),
   teacherStyle: z.string(),
   referral: z.string(),
+  scheduledClasses: z
+    .array(
+      z.object({
+        day: z.string(),
+        startTime: z.string(),
+        classTime: z.number(),
+      }),
+    )
+    .optional(),
 });
 
 type ParentsRequestSchema = z.infer<typeof parentsRequestSchema>;

--- a/app/components/admin/ParentsRequest.tsx
+++ b/app/components/admin/ParentsRequest.tsx
@@ -23,7 +23,21 @@ function ParentsRequest({ applicationFormId }: { applicationFormId: string }) {
             maxWidth="1/5"
             direction="vertical"
           />
-
+          <TitleDesc
+            title={PARENTS_REQUEST_TITLE.scheduledClasses}
+            desc={
+              data?.scheduledClasses && data.scheduledClasses.length > 0
+                ? data.scheduledClasses
+                    .map((cls) => {
+                      const hour = parseInt(cls.startTime.split(":")[0], 10);
+                      return `${cls.day} ${hour}시부터 (${cls.classTime}분)`;
+                    })
+                    .join(", ")
+                : "상담 결과 미전달"
+            }
+            maxWidth="1/5"
+            direction="vertical"
+          />
           <TitleDesc
             title={PARENTS_REQUEST_TITLE.childAge}
             desc={data ? data.age : "아이 나이"}

--- a/app/constants/parentsRequest.ts
+++ b/app/constants/parentsRequest.ts
@@ -10,4 +10,5 @@ export const PARENTS_REQUEST_TITLE = {
   teacherCondition: "선생님 조건 및 스타일",
   referral: "알게된 경로",
   dong: "동",
+  scheduledClasses: "확정 수업 정보",
 } as const;

--- a/app/ui/Columns/ParentsColumns.tsx
+++ b/app/ui/Columns/ParentsColumns.tsx
@@ -20,6 +20,25 @@ export function getParentColumns(
       header: "수업 시수",
       cell: (props) => props.getValue(),
     }),
+    columnHelper.accessor("scheduledClasses", {
+      header: "확정 수업 정보",
+      cell: ({ getValue }) => {
+        const classes = getValue();
+        if (!classes || classes.length === 0) return "-";
+        return (
+          <div className="flex flex-col space-y-1">
+            {classes.map((cls, idx) => {
+              const hour = cls.startTime.split(":")[0];
+              return (
+                <div key={idx}>
+                  {cls.day} {parseInt(hour, 10)}시부터 ({cls.classTime}분)
+                </div>
+              );
+            })}
+          </div>
+        );
+      },
+    }),
     columnHelper.accessor("pay", {
       header: "월 수업료",
       cell: (info) => formatMonthlyFee(info.getValue()),


### PR DESCRIPTION
## 🐈 PR 요약
> PR 내용 한 줄로 요약
- 관련 테크스펙 링크 : -

## ✨ PR 상세
> PR 상세 내용 개조식으로 작성

- 학부모 매칭 리스트 및 요청사항 탭에 상담 결과에 따른 수업 요일,시간 추가했습니다.

## 🚨 참고사항
> 리뷰어들이 알아야 하거나 알면 좋은 참고사항 작성

-

## 📸 스크린샷
> 화면 캡쳐 이미지

![스크린샷 2025-04-08 오후 6 02 33](https://github.com/user-attachments/assets/b15589a5-d4df-451a-8a02-60179d442801)
![스크린샷 2025-04-08 오후 6 04 56](https://github.com/user-attachments/assets/610c6f3c-909e-4662-b891-599e3aaabc21)
![스크린샷 2025-04-08 오후 6 05 04](https://github.com/user-attachments/assets/19ecf448-d5f4-40fd-becb-0dc03095a4f5)


## ✅ 체크리스트
- [x] Reviewers 태그했나요?
- [x] Label 지정했나요?
- [] 관련 테크스펙 링크 연결했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
	- 부모 관련 정보에 확정 수업 데이터를 추가하여, 수업 일정(요일, 시작 시간, 수업 지속시간)을 확인할 수 있습니다.
	- 업데이트된 사용자 인터페이스를 통해 부모 요청 및 목록에서 확정 수업 정보가 명확하게 표시되며, 정보가 없을 경우 별도 안내가 제공됩니다.
	- 새로운 제목 및 설명 구성 요소가 도입되어, 확정 수업 관련 정보를 보다 쉽게 이해할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->