### PR TITLE
Feat/TimeTableHeader 컴포넌트 구현

### DIFF
--- a/app/components/teacher/TimeTable/TimeTableHeader.tsx
+++ b/app/components/teacher/TimeTable/TimeTableHeader.tsx
@@ -1,0 +1,51 @@
+import { ReactNode } from "react";
+
+import cn from "@/utils/cn";
+
+interface TimerTableHeaderProps {
+  children: ReactNode;
+  className?: string;
+}
+
+function TimeTableHeader({ children, className }: TimerTableHeaderProps) {
+  return (
+    <div className={cn("flex flex-col items-start gap-[8px]", className)}>
+      {children}
+    </div>
+  );
+}
+
+TimeTableHeader.Title = function SubtitleTitle({
+  className,
+  children,
+}: {
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <div className={cn("text-[22px] font-bold leading-[140%]", className)}>
+      {children}
+    </div>
+  );
+};
+
+TimeTableHeader.Description = function SubtitleDescription({
+  children,
+  className,
+}: {
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <div
+      className={cn(
+        "text-[16px] font-medium leading-normal text-grey-400",
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+};
+
+export default TimeTableHeader;

--- a/app/constants/result/resultImg.ts
+++ b/app/constants/result/resultImg.ts
@@ -1,6 +1,6 @@
 import { ImgKind } from "@/ui/Result";
 
-import Letter from "../../../public/images/Letter.svg";
+import Letter from "public/images/Letter.svg";
 
 export const RESULT_IMG_MAP = {
   letter: Letter,


### PR DESCRIPTION
## 🐈 PR 요약
> 타임테이블 헤더를 재사용가능한 컴포넌트로 구현
- 관련 테크스펙 링크 : 

## ✨ PR 상세
> 합성컴포넌트로 구현하여 각 요소 스타일 덮어씌울수 있게 했씁니다

## 🚨 참고사항
> 리뷰어들이 알아야 하거나 알면 좋은 참고사항 작성

## 📸 스크린샷
> 사용 예시
<img width="212" alt="image" src="https://github.com/user-attachments/assets/9fdd3fb3-dc26-4b23-a585-0c3083303afe" />
> 적용 예시
<img width="261" alt="image" src="https://github.com/user-attachments/assets/3b1201b4-e941-4df5-b455-5be5d71245e7" />


## ✅ 체크리스트
- [ ] Reviewers 태그했나요?
- [ ] Label 지정했나요?
- [ ] 관련 테크스펙 링크 연결했나요?
