### PR TITLE
Feat/Fix/선생님-타임테이블-업데이트

### DIFF
--- a/app/actions/get-teacher-all-detail/index.ts
+++ b/app/actions/get-teacher-all-detail/index.ts
@@ -1,6 +1,5 @@
 import { httpService } from "@/utils/httpService";
-
-import { DayOfWeek } from "../get-teacher-detail";
+import { DayOfWeek } from "@/actions/get-teacher-detail";
 
 export interface TeacherTokenParams {
   token: string;

--- a/app/actions/put-teacher-available/index.ts
+++ b/app/actions/put-teacher-available/index.ts
@@ -4,7 +4,9 @@ export const putTeacherAvailable = async ({
   name,
   phoneNumber,
   available,
+  token,
 }: {
+  token?: string;
   name: string;
   phoneNumber: string;
   available: Record<string, string[]>;
@@ -17,6 +19,16 @@ export const putTeacherAvailable = async ({
       newPostTimes.push(value.map((time) => time.substring(0, 5)));
     }
   }
+  if (token) {
+    const { data } = await httpService.put<string>(
+      `/teacher/token/info/available`,
+      {
+        token,
+        dayTimes: newPostTimes,
+      },
+    );
+    return data;
+  }
 
   const response = await httpService.put<string>(`/teacher/info/available`, {
     name,
@@ -25,4 +37,23 @@ export const putTeacherAvailable = async ({
   });
 
   return response.data;
+};
+
+export const putTeacherAvailableToken = async (
+  token: string,
+  available: Record<string, string[]>,
+) => {
+  const dayTimes = Object.entries(available).map(([day, times]) => ({
+    day,
+    times: times.map((t) => t.slice(0, 5)),
+  }));
+
+  const { data } = await httpService.put<string>(
+    `/teacher/token/info/available`,
+    {
+      token,
+      dayTimes,
+    },
+  );
+  return data;
 };

--- a/app/components/teacher/TeacherSetting/TeacherSettingTime.tsx
+++ b/app/components/teacher/TeacherSetting/TeacherSettingTime.tsx
@@ -1,7 +1,7 @@
 // teacher 모드 TimeTable
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { CircularProgress } from "@mui/material";
 
@@ -45,6 +45,8 @@ export function TeacherSettingTime() {
     { enabled: isQueryEnabled },
   );
 
+  const initialTime = useMemo(() => data?.available ?? {}, [data]);
+
   const {
     currentTime,
     selectedCell,
@@ -54,7 +56,15 @@ export function TeacherSettingTime() {
     handleCellUnclick,
     handleTeacherSubmit,
     closeSnackbar,
-  } = useTimeTable(data?.available ?? {}, teacherName, teacherPhone, "teacher");
+  } = useTimeTable(
+    initialTime,
+    teacherName,
+    teacherPhone,
+    "teacher",
+    undefined,
+    undefined,
+    token ?? "",
+  );
 
   const {
     isModalOpen,

--- a/app/hooks/mutation/usePutAvailableTeacherTime.ts
+++ b/app/hooks/mutation/usePutAvailableTeacherTime.ts
@@ -1,9 +1,24 @@
 import { useMutation } from "@tanstack/react-query";
 
-import { putTeacherAvailable } from "@/actions/put-teacher-available";
+import {
+  putTeacherAvailable,
+  putTeacherAvailableToken,
+} from "@/actions/put-teacher-available";
 
 export function useUpdateTeacherAvailable() {
   return useMutation({
     mutationFn: putTeacherAvailable,
+  });
+}
+
+export function useUpdateTeacherAvailableWithToken() {
+  return useMutation({
+    mutationFn: ({
+      token,
+      available,
+    }: {
+      token: string;
+      available: Record<string, string[]>;
+    }) => putTeacherAvailableToken(token, available),
   });
 }


### PR DESCRIPTION
## 🐈 PR 요약
> 알림톡(토큰)으로 타임테이블 접근시 업데이트 api 연결
- 관련 테크스펙 링크 : 

## ✨ PR 상세
> useEffect 무한루프 이슈

기존 useTimeTable훅에 전달되는 initialData에서 빈 객체의 새로운 참조가 전달되면서 data가 비어있는 경우 useEffect의 무한루프가 발생했습니다. useMemo를 사용해서 동일한 참조를 갖도록 수정하였습니다.

> put api 연결

토큰이 있을시 토큰api로 put요청보내도록 로직 추가하였습니다.

## 🚨 참고사항
> 리뷰어들이 알아야 하거나 알면 좋은 참고사항 작성

## 📸 스크린샷
> 화면 캡쳐 이미지

## ✅ 체크리스트
- [x] Reviewers 태그했나요?
- [x] Label 지정했나요?
- [ ] 관련 테크스펙 링크 연결했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
	- 토큰 기반으로 선생님의 가능 시간 정보를 업데이트할 수 있는 기능이 추가되었습니다.
- **버그 수정**
	- 없음
- **리팩터**
	- 선생님 가능 시간 업데이트 로직이 토큰 유무에 따라 분기 처리되도록 개선되었습니다.
	- 외부에서 가능 시간 변경을 감지하는 콜백이 제거되었습니다.
- **기타**
	- 내부 훅 및 함수의 시그니처가 일부 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->