### PR TITLE
Feat/TabBar 스크롤 모드추가

### DIFF
--- a/app/(route)/(teacher)/teacher/recommend/[token]/page.tsx
+++ b/app/(route)/(teacher)/teacher/recommend/[token]/page.tsx
@@ -35,6 +35,7 @@ export default function TeacherPage({ params }: { params: { token: string } }) {
         <div className="w-full pb-[60px]">
           <ProfileTop profile={data.profile} nickName={data.nickName} />
           <TabBar
+            scrollMode
             tabs={[
               {
                 trigger: "선생님",

--- a/app/ui/Bar/TabBar.tsx
+++ b/app/ui/Bar/TabBar.tsx
@@ -1,5 +1,7 @@
 "use client";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
+
+import cn from "@/utils/cn";
 
 interface TabInterface {
   trigger: string;
@@ -8,30 +10,82 @@ interface TabInterface {
 
 interface TabBarProps {
   tabs: Array<TabInterface>;
+  scrollMode?: boolean;
 }
 
-export default function TabBar(props: TabBarProps) {
-  const { tabs } = props;
+export default function TabBar({ tabs, scrollMode = false }: TabBarProps) {
   const [selectedTab, setSelectedTab] = useState(tabs[0].trigger);
+  const sectionRefs = useRef<Record<string, HTMLDivElement | null>>({}).current;
+
+  const handleTabClick = (trigger: string) => {
+    setSelectedTab(trigger);
+    if (scrollMode && sectionRefs[trigger]) {
+      sectionRefs[trigger].scrollIntoView({
+        behavior: "smooth",
+        block: "start",
+      });
+    }
+  };
+
+  useEffect(() => {
+    if (!scrollMode) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            const matched = Object.entries(sectionRefs).find(
+              ([, el]) => el === entry.target,
+            );
+            if (matched) setSelectedTab(matched[0]);
+          }
+        });
+      },
+      { rootMargin: "-50% 0px -50% 0px", threshold: 0 },
+    );
+
+    Object.values(sectionRefs).forEach((section) => {
+      if (section) observer.observe(section);
+    });
+
+    return () => observer.disconnect();
+  }, [scrollMode, tabs]);
 
   return (
     <div className="w-full">
-      <div className="flex w-full gap-6 border-b border-tabBarBorder px-4">
+      <div className="sticky top-0 z-10 flex w-full gap-6 border-b border-tabBarBorder bg-white px-4">
         {tabs.map((tab) => (
           <button
             key={tab.trigger}
-            className={`flex-1 border-b-2 py-[15px] text-center font-pretendard font-bold leading-[146%] tracking-[-0.02em] ${
-              selectedTab === tab.trigger
-                ? "border-primaryNormal text-primaryNormal"
-                : "border-transparent text-labelNeutral"
-            }`}
-            onClick={() => setSelectedTab(tab.trigger)}
+            className={cn(
+              "flex-1 border-b-2 border-transparent py-[15px] text-center font-pretendard font-bold leading-[146%] tracking-[-0.02em] text-labelNeutral",
+              selectedTab === tab.trigger &&
+                "border-primaryNormal text-primaryNormal",
+            )}
+            onClick={() => handleTabClick(tab.trigger)}
           >
             {tab.trigger}
           </button>
         ))}
       </div>
-      <div>{tabs.find((tab) => tab.trigger === selectedTab)?.content}</div>
+
+      {scrollMode ? (
+        <div className="space-y-12">
+          {tabs.map((tab) => (
+            <div
+              key={tab.trigger}
+              ref={(el) => {
+                sectionRefs[tab.trigger] = el;
+              }}
+              className="scroll-mt-20"
+            >
+              {tab.content}
+            </div>
+          ))}
+        </div>
+      ) : (
+        <div>{tabs.find((tab) => tab.trigger === selectedTab)?.content}</div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## 🐈 PR 요약
> 기존 <TabBar> 컴포넌트에 스크롤 모드 추가
- 관련 테크스펙 링크 : 

## ✨ PR 상세
>TabBar 컴포넌트에 scrollMode props 추가

•	true일 경우, 각 탭 콘텐츠가 한 페이지에 모두 렌더링되고 탭 클릭 시 스크롤 이동, 스크롤 위치에 따라 탭 자동 선택 동작이 활성화됩니다.
•	IntersectionObserver를 활용하여 뷰포트 중앙에 해당 섹션이 들어오면 selectedTab 자동 변경
•	선택된 탭의 콘텐츠만 렌더링하는 기존 방식도 scrollMode: false로 유지 가능


## 📸 스크린샷

https://github.com/user-attachments/assets/e005a9ef-c62e-4c2a-be66-6cc2981d0e3b


## ✅ 체크리스트
- [x] Reviewers 태그했나요?
- [x] Label 지정했나요?
- [ ] 관련 테크스펙 링크 연결했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 탭바(TabBar)에 스크롤 모드(scrollMode) 옵션이 추가되어, 탭과 콘텐츠 영역이 동기화된 스크롤 및 자동 탭 선택 기능이 제공됩니다. 스크롤 모드 활성화 시 탭 클릭 시 해당 섹션으로 부드럽게 이동하며, 스크롤 시 현재 보이는 섹션에 맞춰 탭이 자동으로 선택됩니다.
- **스타일**
  - 스크롤 모드에서 탭바가 고정(sticky)되어 스크롤 중에도 항상 상단에 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->