### PR TITLE
Feat/timetable multi page support : 병훈 QA

### DIFF
--- a/app/(route)/(teacher)/teacher/notify/[token]/select-time/page.tsx
+++ b/app/(route)/(teacher)/teacher/notify/[token]/select-time/page.tsx
@@ -73,7 +73,7 @@ export default function TeacherClassMatchingSelectTimePage({ params }: Props) {
       initialAvailable={initialAvailable}
       submitLabel="매칭 신청하기"
       onSubmit={handleMatch}
-      alwaysEnableSubmit
+      requireCellSelection
       disableUnsavedWarning
       onBackButtonConfirm={() => window.history.back()}
       onPopstateConfirm={() => window.history.back()}

--- a/app/(route)/(teacher)/teacher/notify/[token]/select-time/page.tsx
+++ b/app/(route)/(teacher)/teacher/notify/[token]/select-time/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { CircularProgress } from "@mui/material";
 
@@ -20,6 +21,12 @@ export default function TeacherClassMatchingSelectTimePage({ params }: Props) {
   const { data, isLoading, isError } = useGetTutoring({ token: matchingToken });
   const { mutateAsync: updateAvailable } = useUpdateTeacherAvailableWithToken();
   const { mutate: acceptMatch } = usePostTutoringAccept();
+
+  useEffect(() => {
+    if (data && data.matchStatus !== "대기") {
+      router.replace(`/teacher/notify/${matchingToken}/complete`);
+    }
+  }, [data, router, matchingToken]);
 
   if (isLoading) {
     return (
@@ -49,6 +56,9 @@ export default function TeacherClassMatchingSelectTimePage({ params }: Props) {
         {
           onSuccess: () => {
             router.push(`/teacher/notify/${matchingToken}/complete`);
+          },
+          onError: () => {
+            alert("이미 신청한 매칭건입니다.");
           },
         },
       );

--- a/app/(route)/(teacher)/teacher/notify/[token]/select-time/page.tsx
+++ b/app/(route)/(teacher)/teacher/notify/[token]/select-time/page.tsx
@@ -1,4 +1,3 @@
-// src/app/teacher/[token]/select-time/page.tsx
 "use client";
 
 import { useRouter } from "next/navigation";
@@ -64,6 +63,7 @@ export default function TeacherClassMatchingSelectTimePage({ params }: Props) {
       initialAvailable={initialAvailable}
       submitLabel="매칭 신청하기"
       onSubmit={handleMatch}
+      alwaysEnableSubmit
       disableUnsavedWarning
       onBackButtonConfirm={() => window.history.back()}
       onPopstateConfirm={() => window.history.back()}

--- a/app/components/teacher/TeacherSetting/TeacherSettingTime.tsx
+++ b/app/components/teacher/TeacherSetting/TeacherSettingTime.tsx
@@ -18,6 +18,7 @@ import TitleSection from "@/ui/TitleSection";
 import HeaderWithBack from "@/components/result/HeaderWithBack";
 
 interface TeacherSettingTimeProps {
+  alwaysEnableSubmit?: boolean;
   submitLabel?: string;
   onSubmit?: (currentTime: Record<string, string[]>) => void;
   onPopstateConfirm?: () => void;
@@ -34,6 +35,7 @@ interface TeacherSettingTimeProps {
 }
 
 export function TeacherSettingTime({
+  alwaysEnableSubmit = false,
   submitLabel = "변경된 시간 저장",
   onSubmit,
   onPopstateConfirm,
@@ -161,7 +163,7 @@ export function TeacherSettingTime({
         <div className="sticky bottom-0 mx-5 bg-white pb-[10px]">
           <div className="absolute top-[-20px] h-[20px] w-full bg-gradient-to-t from-white to-transparent" />
           <Button
-            disabled={!hasChanges}
+            disabled={!hasChanges && !alwaysEnableSubmit}
             onClick={handleClick}
             className="h-[59px]"
           >

--- a/app/components/teacher/TeacherSetting/TeacherSettingTime.tsx
+++ b/app/components/teacher/TeacherSetting/TeacherSettingTime.tsx
@@ -18,7 +18,7 @@ import TitleSection from "@/ui/TitleSection";
 import HeaderWithBack from "@/components/result/HeaderWithBack";
 
 interface TeacherSettingTimeProps {
-  alwaysEnableSubmit?: boolean;
+  requireCellSelection?: boolean;
   submitLabel?: string;
   onSubmit?: (currentTime: Record<string, string[]>) => void;
   onPopstateConfirm?: () => void;
@@ -35,7 +35,7 @@ interface TeacherSettingTimeProps {
 }
 
 export function TeacherSettingTime({
-  alwaysEnableSubmit = false,
+  requireCellSelection = false,
   submitLabel = "변경된 시간 저장",
   onSubmit,
   onPopstateConfirm,
@@ -163,7 +163,11 @@ export function TeacherSettingTime({
         <div className="sticky bottom-0 mx-5 bg-white pb-[10px]">
           <div className="absolute top-[-20px] h-[20px] w-full bg-gradient-to-t from-white to-transparent" />
           <Button
-            disabled={!hasChanges && !alwaysEnableSubmit}
+            disabled={
+              requireCellSelection
+                ? !Object.values(currentTime).some((slots) => slots.length > 0)
+                : !hasChanges
+            }
             onClick={handleClick}
             className="h-[59px]"
           >

--- a/app/components/teacher/TimeTable/useTimeTable.ts
+++ b/app/components/teacher/TimeTable/useTimeTable.ts
@@ -90,7 +90,7 @@ export function useTimeTable(
             setSnackbarOpen(true);
           } else {
             setSnackbarMessage(
-              `${sessionDuration}분 수업이라 이 시간은 선택할 수 없어요.`,
+              `${sessionDuration}분 수업이라 이 시간은 선택할 수 없어요`,
             );
             setSnackbarOpen(true);
           }
@@ -200,8 +200,8 @@ export function useTimeTable(
         onSuccess: () => {
           router.push(`/teacher/recommend/${classMatchingToken}/complete`);
         },
-        onError: (error) => {
-          setSnackbarMessage(error.message);
+        onError: () => {
+          setSnackbarMessage("이미 신청한 매칭건입니다.");
           setSnackbarOpen(true);
         },
       },

--- a/app/hooks/query/useGetTutoringDetail.ts
+++ b/app/hooks/query/useGetTutoringDetail.ts
@@ -6,7 +6,8 @@ export function useGetTutoring({ token }: { token: string }) {
   return useSuspenseQuery({
     queryKey: ["tutoring", token],
     queryFn: () => getTutoring({ token }),
-    staleTime: Infinity,
+    staleTime: 0,
+    refetchOnMount: true,
     retry: 0,
   });
 }

--- a/app/ui/Snackbar/index.tsx
+++ b/app/ui/Snackbar/index.tsx
@@ -19,7 +19,7 @@ export default function GlobalSnackbar({
   icon,
   message,
   onClose,
-  duration = 1800,
+  duration = 1500,
   anchor = { vertical: "top", horizontal: "center" },
 }: GlobalSnackbarProps) {
   return (
@@ -28,11 +28,16 @@ export default function GlobalSnackbar({
       onClose={onClose}
       autoHideDuration={duration}
       anchorOrigin={anchor}
-      sx={{ top: "80%", mx: "20px" }}
+      sx={{
+        top: "83% !important",
+        left: "50% !important",
+        transform: "translateX(-50%) !important",
+        width: "max-content !important",
+      }}
       message={
         <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
           {icon}
-          <Box component="span" sx={{ flex: 1, textAlign: "center" }}>
+          <Box component="span" sx={{ textAlign: "center", fontWeight: 600 }}>
             {message}
           </Box>
         </Box>
@@ -44,7 +49,7 @@ export default function GlobalSnackbar({
             padding: "6px 18px",
             justifyContent: "center",
             alignItems: "center",
-            backgroundColor: "rgba(87, 101, 122, 0.8)",
+            backgroundColor: "#64748B",
           },
         },
       }}


### PR DESCRIPTION
## 🐈 PR 요약
> PR 내용 한 줄로 요약
- 관련 테크스펙 링크 : -

## ✨ PR 상세
> PR 상세 내용 개조식으로 작성

- 매칭 수락/거절 타임테이블에서는 변경사항 없어도 버튼 활성화되도록
- 매칭 수락/거절 타임테이블 공란일 경우 매칭버튼 비활성화
- 중복 제출 시 Axios Error 문구 변경
- 스낵바 디자인 수정
- 매칭 수락/거절 제출 후 뒤로가기 누를 경우 다시 결과페이지로 강제 라우팅

## 🚨 참고사항
> 리뷰어들이 알아야 하거나 알면 좋은 참고사항 작성

## 📸 스크린샷
> 화면 캡쳐 이미지

## ✅ 체크리스트
- [x] Reviewers 태그했나요?
- [x] Label 지정했나요?
- [x] 관련 테크스펙 링크 연결했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 시간 선택 시 셀 선택 필수 여부를 설정할 수 있는 옵션이 추가되었습니다.
    - 매칭 상태가 '대기'가 아닐 경우 자동으로 완료 페이지로 이동합니다.

- **버그 수정**
    - 이미 신청된 매칭에 대해 알림 메시지가 정확하게 표시됩니다.

- **스타일**
    - 스낵바의 위치, 색상, 글꼴 굵기, 표시 시간이 개선되어 더 명확하게 안내 메시지가 노출됩니다.

- **기타**
    - 시간표 제출 버튼의 활성화 조건이 변경되었습니다.
    - 튜터링 상세 정보가 매번 새로고침되어 최신 상태를 반영합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->