### PR TITLE
fix: ios에서 터치 딜레이로 Ghost Click 되는 오류 해결

### DIFF
--- a/app/components/teacher/TimeTable/index.tsx
+++ b/app/components/teacher/TimeTable/index.tsx
@@ -126,7 +126,14 @@ export default function TimeTable({
                     key={time}
                     role={clickable ? "button" : undefined}
                     tabIndex={clickable ? 0 : undefined}
-                    onClick={toggle}
+                    onClick={() => {
+                      toggle();
+                    }}
+                    // iOS/Safari ghost click 방지
+                    onTouchEnd={(e) => {
+                      e.preventDefault();
+                      toggle();
+                    }}
                     onKeyDown={(e) =>
                       clickable &&
                       (e.key === "Enter" || e.key === " ") &&


### PR DESCRIPTION
## 🐈 PR 요약
> PR 내용 한 줄로 요약
- 관련 테크스펙 링크 : -

## ✨ PR 상세
> PR 상세 내용 개조식으로 작성

ios 에서 터치 딜레이로 인해 이전 터치 위치가 다시 터치되는 문제 해결했습니다.

## 🚨 참고사항
> 리뷰어들이 알아야 하거나 알면 좋은 참고사항 작성

모바일에서 터치 동작 시 두번탭 동작을 구분하기 위해 300ms의 딜레이를 두는데
이로 인해 터치가 의도한 대로 동작하지 않는 문제가 있다고 해요.
모바일에서는 onClick 에 추가로 touchEnd나 touchStart를 쓰면 해결된다고합니다.

## 📸 스크린샷
> 화면 캡쳐 이미지

## ✅ 체크리스트
- [x] Reviewers 태그했나요?
- [x] Label 지정했나요?
- [x] 관련 테크스펙 링크 연결했나요?
