### PR TITLE
fix: teacher/[id] 페이지 추가 + UX 문구 수정

### DIFF
--- a/app/(route)/(teacher)/teacher/[id]/page.tsx
+++ b/app/(route)/(teacher)/teacher/[id]/page.tsx
@@ -1,0 +1,89 @@
+"use client"; // client component 분리는 리팩토링때 진행하겠습니다 😅
+import { ErrorBoundary } from "react-error-boundary";
+import { useSearchParams } from "next/navigation";
+
+import TeacherDetailRegionTime from "@/components/teacher/TeacherDetail/TeacherDetailRegionTime";
+import ProfileTop from "@/components/teacher/ProfileTop";
+import TeacherDetailClass from "@/components/teacher/TeacherDetail/TeacherDetailClass";
+import TeacherDetailMain from "@/components/teacher/TeacherDetail/TeacherDetailMain";
+import TabBar from "@/ui/Bar/TabBar";
+import ErrorUI from "@/ui/ErrorUI";
+import { SubjectType } from "@/actions/get-teacher-detail";
+import { useGetTeacherAllDetailsByTeacherId } from "@/hooks/query/useGetTeacherDetails";
+
+export default function TeacherIdPage({ params }: { params: { id: string } }) {
+  const { id: teacherId } = params;
+  const searchParams = useSearchParams();
+  const subject = searchParams.get("subject") as SubjectType;
+  const { data, isLoading, error } = useGetTeacherAllDetailsByTeacherId({
+    teacherId,
+    subject,
+  });
+
+  if (isLoading) return null;
+  if (error) return <ErrorUI />;
+
+  return (
+    <ErrorBoundary fallback={<ErrorUI />}>
+      {data && (
+        <div className="w-full pb-[60px]">
+          <ProfileTop
+            profile={data.profile || ""}
+            nickName={data.nickName || ""}
+          />
+          <TabBar
+            tabs={[
+              {
+                trigger: "선생님",
+                content: (
+                  <TeacherDetailMain
+                    comment={data.comment || ""}
+                    introduce={data.introduce || ""}
+                    teachingHistory={data.teachingHistory || 0}
+                    teachingExperiences={data.teachingExperiences || []}
+                    foreignExperiences={data.foreignExperiences}
+                    university={data.university || ""}
+                    major={data.major || ""}
+                    highSchool={data.highSchool || ""}
+                    teachingStyle1={data.teachingStyle1 || ""}
+                    teachingStyleInfo1={data.teachingStyleInfo1 || ""}
+                    teachingStyle2={data.teachingStyle2 || ""}
+                    teachingStyleInfo2={data.teachingStyleInfo2 || ""}
+                  />
+                ),
+              },
+              {
+                trigger: "수업",
+                content: (
+                  <TeacherDetailClass
+                    teachingStyle={data.teachingStyle || ""}
+                    video={data.video}
+                  />
+                ),
+              },
+              {
+                trigger: "지역/시간",
+                content: (
+                  <TeacherDetailRegionTime
+                    districts={data.districts || []}
+                    available={
+                      data.available || {
+                        월: [],
+                        화: [],
+                        수: [],
+                        목: [],
+                        금: [],
+                        토: [],
+                        일: [],
+                      }
+                    }
+                  />
+                ),
+              },
+            ]}
+          />
+        </div>
+      )}
+    </ErrorBoundary>
+  );
+}

--- a/app/actions/get-teacher-detail/index.ts
+++ b/app/actions/get-teacher-detail/index.ts
@@ -33,7 +33,7 @@ export interface TeacherDetailsClassResponse {
 
 export interface TeacherDetailsAvailableResponse {
   districts: Array<string>;
-  availables: {
+  available: {
     [key in DayOfWeek]: Array<string>;
   };
 }

--- a/app/components/teacher/TeacherDetail/TeacherDetailChooseTime.tsx
+++ b/app/components/teacher/TeacherDetail/TeacherDetailChooseTime.tsx
@@ -60,7 +60,7 @@ export default function TeacherDetailChooseTime() {
           주세요
         </TitleSection.Title>
         <TitleSection.Description>
-          선생님이 가능한 시간이에요
+          색칠된 시간 중에서 골라주세요
         </TitleSection.Description>
       </TitleSection>
 

--- a/app/hooks/query/useGetTeacherDetails.ts
+++ b/app/hooks/query/useGetTeacherDetails.ts
@@ -1,4 +1,4 @@
-import { useQuery, useSuspenseQuery } from "@tanstack/react-query";
+import { useQuery, useSuspenseQuery, useQueries } from "@tanstack/react-query";
 
 import {
   TeacherDetailsParams,
@@ -61,4 +61,62 @@ export function useGetTeacherDetailsInfo(params: TeacherSimpleDetailsParams) {
     staleTime: 1000 * 60 * 60,
     gcTime: 1000 * 60 * 60 * 24,
   });
+}
+
+export function useGetTeacherAllDetailsByTeacherId(
+  params: TeacherDetailsParams,
+) {
+  const results = useQueries({
+    queries: [
+      {
+        queryKey: ["teacher-details-teacher", params],
+        queryFn: () => getTeacherDetailsTeacher(params),
+        retry: 0,
+        staleTime: 1000 * 60 * 60,
+        gcTime: 1000 * 60 * 60 * 24,
+      },
+      {
+        queryKey: ["teacher-details-class", params],
+        queryFn: () => getTeacherDetailsClass(params),
+        retry: 0,
+        staleTime: Infinity,
+        gcTime: Infinity,
+      },
+      {
+        queryKey: ["teacher-details-available", params],
+        queryFn: () =>
+          getTeacherDetailsAvailable({ teacherId: params.teacherId }),
+        retry: 0,
+        staleTime: Infinity,
+        gcTime: Infinity,
+      },
+      {
+        queryKey: ["teacher-details-info", params],
+        queryFn: () => getTeacherDetailsInfo({ teacherId: params.teacherId }),
+        retry: 0,
+        staleTime: 1000 * 60 * 60,
+        gcTime: 1000 * 60 * 60 * 24,
+      },
+    ],
+  });
+
+  const [teacherDetails, classDetails, availableDetails, infoDetails] = results;
+
+  const isLoading = results.some((result) => result.isLoading);
+  const isError = results.some((result) => result.isError);
+  const error = results.find((result) => result.error)?.error;
+
+  const data = {
+    ...teacherDetails.data,
+    ...classDetails.data,
+    ...availableDetails.data,
+    ...infoDetails.data?.data,
+  };
+
+  return {
+    data,
+    isLoading,
+    isError,
+    error,
+  };
 }


### PR DESCRIPTION
## 🐈 PR 요약
> PR 내용 한 줄로 요약
- 관련 테크스펙 링크 : https://www.notion.so/UX-1e2afa1037b28076a7c7ff8f30698a66
- /teacher/[id]?subject=[subject] 페이지 다시 추가
- '선생님이 가능한 시간이에요' -> '색칠된 시간 중에서 골라주세요' 문구 변경

## ✨ PR 상세
> PR 상세 내용 개조식으로 작성
- 원래의 선생님 상세 페이지에서는 탭별로 api 호출해서(이미지/닉네임 정보까지 총 4개) 데이터를 보여주는 개념이었고, 그래서 `teacherId`로 받아오는 페이지에서는 해당 api들 사용해야 했음 → `useQuries`로 받아오게 구현했습니당

## 🚨 참고사항
> 리뷰어들이 알아야 하거나 알면 좋은 참고사항 작성
https://www.notion.so/block-height-1e2afa1037b2803b9fd8e29c8e7fe014
↑ 보고된 이슈 중에 이거는 스크롤 관련해서 생기는 문제인 것 같아서 예영님이 한번 봐주시면 좋을 것 같아요! 

## 📸 스크린샷
> 화면 캡쳐 이미지
화면 변경은 X

## ✅ 체크리스트
- [x] Reviewers 태그했나요?
- [x] Label 지정했나요?
- [x] 관련 테크스펙 링크 연결했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 선생님 상세 정보를 보여주는 페이지가 추가되었습니다. 탭을 통해 선생님 정보, 수업 정보, 지역/시간 정보를 확인할 수 있습니다.
- **버그 수정**
  - 선생님 가능 시간 안내 문구가 "색칠된 시간 중에서 골라주세요"로 변경되었습니다.
- **스타일/문구**
  - 사용자에게 보여지는 안내 메시지가 더 명확하게 수정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->