### PR TITLE
fix: 타임테이블 영역 스크롤 할 때 셀도 함께 클릭되는 문제 해결

### DIFF
--- a/app/components/teacher/TimeTable/index.tsx
+++ b/app/components/teacher/TimeTable/index.tsx
@@ -22,6 +22,10 @@ interface TimeTableProps {
 const WEEK = ["월", "화", "수", "목", "금", "토", "일"];
 const times = getSplitHoursToStringFormat();
 const gaps = [18, 24, 10, 16, ...Array(times.length - 4).fill(24), 0];
+const isIOS =
+  typeof navigator !== "undefined" &&
+  /iPad|iPhone|iPod/.test(navigator.userAgent) &&
+  !("MSStream" in window);
 
 export default function TimeTable({
   mode,
@@ -126,19 +130,18 @@ export default function TimeTable({
                     key={time}
                     role={clickable ? "button" : undefined}
                     tabIndex={clickable ? 0 : undefined}
-                    onClick={() => {
-                      toggle();
-                    }}
-                    // iOS/Safari ghost click 방지
-                    onTouchEnd={(e) => {
-                      e.preventDefault();
-                      toggle();
-                    }}
+                    onPointerUp={isIOS ? () => toggle() : undefined}
+                    onClick={!isIOS ? () => toggle() : undefined}
                     onKeyDown={(e) =>
                       clickable &&
                       (e.key === "Enter" || e.key === " ") &&
                       toggle()
                     }
+                    style={{
+                      touchAction: "pan-y",
+                      cursor: "pointer",
+                      overscrollBehaviorY: "contain",
+                    }}
                     className={`flex-1 border border-gray-300 ${dIdx !== WEEK.length - 1 ? "border-r-0" : ""} ${tIdx !== times.length - 1 ? "border-b-0" : ""} ${bgClass} ${cornerClass} `}
                   />
                 );


### PR DESCRIPTION
## 🐈 PR 요약
> PR 내용 한 줄로 요약
- 관련 테크스펙 링크 : 

## ✨ PR 상세
> PR 상세 내용 개조식으로 작성

- ios에서 타임테이블 셀을 연달아 클릭할 때 ghost click 문제로 이전 클릭했던 영역이 한번 더 클릭되면서 취소되는 문제가 있었습니다. 이를 해결하기 위해 onTouchEnd 를 사용했으나 이로 인해 해당 영역에서 스크롤할 경우 셀 클릭이 되는 문제가 생겼어요. 그래서 onPointerUp으로 변경했고 ios이외의 브라우저에서는 기존대로 onClick을 사용하도록 했습니다. 

## 🚨 참고사항
> 리뷰어들이 알아야 하거나 알면 좋은 참고사항 작성

## 📸 스크린샷
> 화면 캡쳐 이미지

## ✅ 체크리스트
- [x] Reviewers 태그했나요?
- [x] Label 지정했나요?
- [x] 관련 테크스펙 링크 연결했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - iOS 기기에서 시간표 셀 클릭 시 발생하던 유령 클릭(ghost click) 문제를 해결했습니다.

- **스타일**
  - 시간표 셀에 터치 및 스크롤 관련 스타일이 추가되어, 터치 환경에서의 사용성이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->