### PR TITLE
Fix/timetable bh qa : 매칭 수락/거절 페이지 타임테이블 로딩표시 추가

### DIFF
--- a/app/(route)/(teacher)/teacher/notify/[token]/select-time/page.tsx
+++ b/app/(route)/(teacher)/teacher/notify/[token]/select-time/page.tsx
@@ -71,13 +71,20 @@ export default function TeacherClassMatchingSelectTimePage({ params }: Props) {
     }
   };
 
+  if (isSubmitting) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <CircularProgress />
+      </div>
+    );
+  }
+
   return (
     <TeacherSettingTime
       pageToken={matchingToken}
       initialAvailable={initialAvailable}
       submitLabel="매칭 신청하기"
       onSubmit={handleMatch}
-      isSubmitting={isSubmitting}
       requireCellSelection
       disableUnsavedWarning
       onBackButtonConfirm={() => window.history.back()}

--- a/app/components/teacher/TeacherSetting/TeacherSettingMain.tsx
+++ b/app/components/teacher/TeacherSetting/TeacherSettingMain.tsx
@@ -94,7 +94,7 @@ export default function TeacherSettingMain() {
       <Modal
         isOpen={showModal}
         title="과외 공지 수신을 중단할까요?"
-        message="수신 중단 시, 더 이상 선생님께 카톡으로 과외 공지를 전송드리지 않아요."
+        message={`수신 중단 시, 더 이상 선생님께 카톡으로\n과외 공지를 전송드리지 않아요.`}
         confirmText="중단"
         cancelText="계속 받기"
         handleOnConfirm={() => {

--- a/app/components/teacher/TeacherSetting/TeacherSettingTime.tsx
+++ b/app/components/teacher/TeacherSetting/TeacherSettingTime.tsx
@@ -21,7 +21,6 @@ interface TeacherSettingTimeProps {
   requireCellSelection?: boolean;
   submitLabel?: string;
   onSubmit?: (currentTime: Record<string, string[]>) => void;
-  isSubmitting?: boolean;
   onPopstateConfirm?: () => void;
   onBackButtonConfirm?: () => void;
   disableUnsavedWarning?: boolean;
@@ -39,7 +38,6 @@ export function TeacherSettingTime({
   requireCellSelection = false,
   submitLabel = "변경된 시간 저장",
   onSubmit,
-  isSubmitting = false,
   onPopstateConfirm,
   onBackButtonConfirm,
   disableUnsavedWarning = false,
@@ -166,19 +164,14 @@ export function TeacherSettingTime({
           <div className="absolute top-[-20px] h-[20px] w-full bg-gradient-to-t from-white to-transparent" />
           <Button
             disabled={
-              isSubmitting ||
-              (requireCellSelection
-                ? !Object.values(currentTime).some((slots) => slots.length > 0)
-                : !hasChanges)
+              requireCellSelection
+                ? !Object.values(currentTime).some((s) => s.length > 0)
+                : !hasChanges
             }
             onClick={handleClick}
-            className="flex h-[59px] items-center justify-center"
+            className="h-[59px] w-full rounded-[12px] font-bold"
           >
-            {isSubmitting ? (
-              <CircularProgress size={24} sx={{ color: "#fff" }} />
-            ) : (
-              submitLabel
-            )}
+            {submitLabel}
           </Button>
         </div>
 


### PR DESCRIPTION
## 🐈 PR 요약
> PR 내용 한 줄로 요약
- 관련 테크스펙 링크 : https://www.notion.so/1e5afa1037b280efb996dc321591b48a?pvs=4

## ✨ PR 상세
> PR 상세 내용 개조식으로 작성

- 매칭 수락/거절 페이지에 매칭신청 버튼을 누르면 전체화면 로딩표시가 되면서 자연스럽게 결과화면으로 넘어가도록 했습니다.

## 🚨 참고사항
> 리뷰어들이 알아야 하거나 알면 좋은 참고사항 작성

- 기존에 로딩표시가 없는 문제를 버튼 로딩표시로 해결했는데 이번에 타임테이블을 변경하고 매칭수락 버튼을 누르면 잠깐 변경 이전의 타임테이블이 보이는 상태가 되어 아예 페이지 자체를 로딩표시로 바꿔 해결했습니다. 기존 버튼 로딩 코드는 삭제했습니다.

## 📸 스크린샷
> 화면 캡쳐 이미지

https://github.com/user-attachments/assets/11579b64-1ffb-45f6-bbaf-fd2284e3d57d

## ✅ 체크리스트
- [x] Reviewers 태그했나요?
- [x] Label 지정했나요?
- [x] 관련 테크스펙 링크 연결했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
	- 시간 선택 화면에서 제출 중일 때 로딩 스피너만 표시되어, 폼이 비활성화되고 중복 제출이 방지됩니다.
- **스타일**
	- 시간 저장 버튼의 디자인이 개선되어 고정 높이, 전체 너비, 둥근 모서리, 볼드체로 변경되었습니다.
	- 안내 모달 메시지가 두 줄로 나뉘어 가독성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->