### PR TITLE
fix: 가능시간 유도 알림톡 타임테이블 기능 수정

### DIFF
--- a/app/(route)/(teachersetting)/teachersetting/time/page.tsx
+++ b/app/(route)/(teachersetting)/teachersetting/time/page.tsx
@@ -1,15 +1,22 @@
 "use client";
 
 import { ErrorBoundary } from "react-error-boundary";
+import { useSearchParams } from "next/navigation";
 
 import { TeacherSettingTime } from "@/components/teacher/TeacherSetting/TeacherSettingTime";
 import ErrorUI from "@/ui/ErrorUI";
+import { useGetTeacherSettingTimeByToken } from "@/hooks/query/useGetTeacherSettingTimeByToken";
 
 export default function TeacherTimeSetting() {
+  const token = useSearchParams().get("token");
+  const { data } = useGetTeacherSettingTimeByToken({
+    token: token || "",
+  });
+
   return (
     <ErrorBoundary fallback={<ErrorUI />}>
       <div className="w-full">
-        <TeacherSettingTime />
+        <TeacherSettingTime initialAvailable={data?.available} />
       </div>
     </ErrorBoundary>
   );

--- a/app/actions/get-teacher-setting-time-by-token/index.ts
+++ b/app/actions/get-teacher-setting-time-by-token/index.ts
@@ -1,0 +1,26 @@
+import { httpService } from "@/utils/httpService";
+
+import { DayOfWeek } from "../get-teacher-setting-info";
+
+export interface TeacherSettingTimeByTokenParams {
+  token: string;
+}
+
+export interface TeacherSettingTimeByTokenResponse {
+  disctricts: Array<string>;
+  available: {
+    [key in DayOfWeek]: Array<string>;
+  };
+}
+
+export async function getTeacherSettingTimeByToken(
+  params: TeacherSettingTimeByTokenParams,
+): Promise<TeacherSettingTimeByTokenResponse> {
+  const { token } = params;
+
+  const res = await httpService.get<TeacherSettingTimeByTokenResponse>(
+    `/teacher/token/info/available?token=${token}`,
+  );
+
+  return res.data;
+}

--- a/app/components/teacher/TimeTable/useTimeTable.ts
+++ b/app/components/teacher/TimeTable/useTimeTable.ts
@@ -163,7 +163,12 @@ export function useTimeTable(
     if (token) {
       patchTimeWithToken(
         { token, available: currentTime },
-        { onSuccess: () => setSnackbarOpen(true) },
+        {
+          onSuccess: () => {
+            setSnackbarOpen(true);
+            setBaseTime(currentTime);
+          },
+        },
       );
       return;
     }

--- a/app/hooks/query/useGetTeacherSettingTimeByToken.ts
+++ b/app/hooks/query/useGetTeacherSettingTimeByToken.ts
@@ -1,0 +1,13 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { getTeacherSettingTimeByToken } from "@/actions/get-teacher-setting-time-by-token";
+
+export function useGetTeacherSettingTimeByToken({ token }: { token: string }) {
+  return useQuery({
+    queryKey: ["teacher-setting-time", token],
+    queryFn: () => getTeacherSettingTimeByToken({ token }),
+    staleTime: 1000 * 60 * 60,
+    gcTime: 1000 * 60 * 60 * 24,
+    enabled: !!token,
+  });
+}


### PR DESCRIPTION
## 🐈 PR 요약
> PR 내용 한 줄로 요약
- 관련 테크스펙 링크 : x
- 가능시간 유도 알림톡으로 가는 타임테이블 페이지 버그 수정

## ✨ PR 상세
> PR 상세 내용 개조식으로 작성
- 기존 가능시간 등록되어 있는 선생님이면 가능시간 불러와서 채워주게 구현 (토큰 사용)
- 변경사항 제출해도 버튼 비활성화 안 되고, 뒤로가기 버튼 누르면 변경사항 저장이 안 됐다는 모달이 뜨는 버그가 있었는데 수정했습니다!
  - 토큰으로 가능시간 업데이트 할 때, `baseTime`이랑 `currentTime` 일치시키도록 구현했어용

## 🚨 참고사항
> 리뷰어들이 알아야 하거나 알면 좋은 참고사항 작성
- 앞으로 복잡한 구현이 있으면 주석을 잘 활용하면 좋겠다는 생각이 들었어요!! 바보라서 코드 해석을 잘 못해서 오래걸렷네욬ㅋ큐ㅠㅠㅠㅠ

## 📸 스크린샷
> 화면 캡쳐 이미지

https://github.com/user-attachments/assets/feedc688-fbc2-486c-9090-f87d1f048d32



## ✅ 체크리스트
- [x] Reviewers 태그했나요?
- [x] Label 지정했나요?
- [ ] 관련 테크스펙 링크 연결했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
	- URL의 토큰 값을 기반으로 교사의 시간 설정 데이터를 동적으로 불러오고 초기화하는 기능이 추가되었습니다.
	- 토큰을 이용한 교사 시간 설정 데이터 조회를 위한 새로운 API 연동 기능이 도입되었습니다.
- **버그 수정**
	- 시간 설정 변경 후, 성공 시 선택한 시간이 바로 반영되어 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->