### PR TITLE
fix: 매칭 수락/거절 페이지 타임테이블 헤더 텍스트 수정

### DIFF
--- a/app/(route)/(teacher)/teacher/notify/[token]/select-time/page.tsx
+++ b/app/(route)/(teacher)/teacher/notify/[token]/select-time/page.tsx
@@ -84,6 +84,8 @@ export default function TeacherClassMatchingSelectTimePage({ params }: Props) {
       pageToken={matchingToken}
       initialAvailable={initialAvailable}
       submitLabel="매칭 신청하기"
+      headerTitle={`과외가 가능한 시간을\n모두 업데이트해주세요`}
+      headerDescription={`학부모님이 선호하는 시간과 상관없이\n평소 수업이 가능한 시간을 모두 선택해주세요`}
       onSubmit={handleMatch}
       requireCellSelection
       disableUnsavedWarning

--- a/app/components/teacher/TeacherSetting/TeacherSettingTime.tsx
+++ b/app/components/teacher/TeacherSetting/TeacherSettingTime.tsx
@@ -18,6 +18,8 @@ import TitleSection from "@/ui/TitleSection";
 import HeaderWithBack from "@/components/result/HeaderWithBack";
 
 interface TeacherSettingTimeProps {
+  headerTitle?: React.ReactNode;
+  headerDescription?: React.ReactNode;
   requireCellSelection?: boolean;
   submitLabel?: string;
   onSubmit?: (currentTime: Record<string, string[]>) => void;
@@ -35,6 +37,8 @@ interface TeacherSettingTimeProps {
 }
 
 export function TeacherSettingTime({
+  headerTitle,
+  headerDescription,
   requireCellSelection = false,
   submitLabel = "변경된 시간 저장",
   onSubmit,
@@ -140,13 +144,11 @@ export function TeacherSettingTime({
 
         {/* 헤더 */}
         <TitleSection className="m-5 mb-10 mt-8">
-          <TitleSection.Title>
-            정말 수업이 가능한 시간을
-            <br />
-            모두 선택해 주세요
+          <TitleSection.Title className="whitespace-pre-line">
+            {headerTitle ?? `정말 수업이 가능한 시간을\n모두 선택해주세요`}
           </TitleSection.Title>
-          <TitleSection.Description>
-            선택한 시간대에 맞는 학부모님과 매칭돼요
+          <TitleSection.Description className="whitespace-pre-line">
+            {headerDescription ?? "선택한 시간대에 맞는 학부모님과 매칭돼요"}
           </TitleSection.Description>
         </TitleSection>
 


### PR DESCRIPTION
## 🐈 PR 요약
> PR 내용 한 줄로 요약
- 관련 테크스펙 링크 : https://www.notion.so/1e5afa1037b280efb996dc321591b48a?pvs=4

## ✨ PR 상세
> PR 상세 내용 개조식으로 작성

- 매칭 수락/거절 페이지의 타임테이블에서는 유저가 학부모의 시간과 관계없이 선택할 수 있도록 헤더 타이틀을 다르게 표시하도록 했습니다.

## 🚨 참고사항
> 리뷰어들이 알아야 하거나 알면 좋은 참고사항 작성

## 📸 스크린샷
> 화면 캡쳐 이미지

<img width="375" alt="스크린샷 2025-05-02 오후 4 43 52" src="https://github.com/user-attachments/assets/13362140-c278-4651-a427-26dc87b91660" />
<img width="375" alt="스크린샷 2025-05-02 오후 4 44 02" src="https://github.com/user-attachments/assets/75259ca8-10b1-4f03-94bd-944b69cbb0cd" />


## ✅ 체크리스트
- [x] Reviewers 태그했나요?
- [x] Label 지정했나요?
- [x] 관련 테크스펙 링크 연결했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - 선생님이 수업 가능 시간을 설정하는 화면에서, 안내 제목과 설명을 맞춤형으로 표시할 수 있도록 개선되었습니다.  
  - 여러 줄 안내 문구가 지원되어, 더 명확한 안내가 제공됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->