### PR TITLE
Fix/session schedule list : 각 탭별 '전체 일정 변경' 기능 오류 수정. 이에 따른 자잘한 코드 수정

### DIFF
--- a/app/(route)/(teacher)/teacher/session-change/page.tsx
+++ b/app/(route)/(teacher)/teacher/session-change/page.tsx
@@ -65,7 +65,8 @@ export default function SessionChangePage() {
             <SessionSchedule
               className="mb-24"
               title={`학부모와 협의 후\n일정을 업데이트해 주세요`}
-              token={token ?? ""}
+              token={classId ? undefined : (token ?? undefined)}
+              classMatchingId={target?.classMatchingId}
               initialSchedules={schedules}
             />
           </HeaderWithBack>

--- a/app/(route)/(teacher)/teacher/session-change/page.tsx
+++ b/app/(route)/(teacher)/teacher/session-change/page.tsx
@@ -41,7 +41,8 @@ export default function SessionChangePage() {
     return result;
   };
 
-  const schedules = convertToSchedules(data?.schedules);
+  const target = data?.find((item) => item.applicationFormId === classId);
+  const schedules = convertToSchedules(target?.schedules);
 
   if (isLoading) {
     return (

--- a/app/(route)/(teacher)/teacher/session-change/page.tsx
+++ b/app/(route)/(teacher)/teacher/session-change/page.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useSearchParams } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { CircularProgress } from "@mui/material";
 
 import { useGetSchedules } from "@/hooks/query/useGetSchedules";
@@ -10,9 +10,15 @@ import { DayOfWeek } from "@/actions/get-teacher-detail";
 import { ClassTimeDTO } from "@/actions/get-schedules";
 
 export default function SessionChangePage() {
+  const router = useRouter();
   const searchParams = useSearchParams();
   const token = searchParams.get("token");
+  const classId = searchParams.get("classid");
   const { data, isLoading } = useGetSchedules({ token: token ?? "" });
+
+  const onClickBack = () => {
+    router.push(`/teacher/session-schedule?token=${token}`);
+  };
 
   const convertToSchedules = (
     scheduleData: Partial<Record<DayOfWeek, ClassTimeDTO[]>> | undefined,
@@ -50,9 +56,10 @@ export default function SessionChangePage() {
       {data && (
         <div className="flex flex-col items-center">
           <HeaderWithBack
-            title={data.applicationFormId || "과외 일정"}
+            title={classId || "과외 일정"}
             mainClassName="pt-8"
             hasBack
+            onBack={onClickBack}
           >
             <SessionSchedule
               className="mb-24"

--- a/app/(route)/(teacher)/teacher/session-complete/page.tsx
+++ b/app/(route)/(teacher)/teacher/session-complete/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useRouter, useSearchParams } from "next/navigation";
+import { useQueryClient } from "@tanstack/react-query";
 import { CircularProgress } from "@mui/material";
 
 import { useGetSchedules } from "@/hooks/query/useGetSchedules";
@@ -8,6 +9,11 @@ import HeaderWithBack from "@/components/result/HeaderWithBack";
 import SessionComplete from "@/components/teacher/Session/SessionComplete";
 import { useGetSessionByToken } from "@/hooks/query/useGetSessionByToken";
 import { formatDateShort } from "@/utils/getDayOfWeek";
+import { SessionResponse } from "@/actions/post-getSessions";
+
+interface SessionsCache {
+  schedules: Record<string, SessionResponse[]>;
+}
 
 export default function SessionCompletePage() {
   const router = useRouter();
@@ -15,8 +21,33 @@ export default function SessionCompletePage() {
   const token = searchParams.get("token");
   const classSessionId = searchParams.get("sessionId");
   const { data, isLoading } = useGetSchedules({ token: token ?? "" });
+  const target = data?.[0];
   const { data: sessionData } = useGetSessionByToken({ token: token ?? "" });
-  const isEmpty = !data || Object.keys(data.schedules ?? {}).length === 0;
+  const isEmpty =
+    !target ||
+    Object.values(target.schedules).every((arr) => (arr ?? []).length === 0);
+
+  const queryClient = useQueryClient();
+  const sessionsCache = queryClient.getQueryData<SessionsCache>([
+    "sessions",
+    token ?? "",
+  ]);
+
+  let cachedDate: string | undefined;
+
+  if (sessionsCache && classSessionId) {
+    for (const arr of Object.values(sessionsCache.schedules)) {
+      const found = arr.find(
+        (s) => s.classSessionId === Number(classSessionId),
+      );
+      if (found) {
+        cachedDate = found.classDate;
+        break;
+      }
+    }
+  }
+
+  const titleDate = cachedDate ? formatDateShort(cachedDate) : "과외 완료";
 
   const onClickBack = () => {
     router.push(`/teacher/session-schedule?token=${token}`);
@@ -36,12 +67,13 @@ export default function SessionCompletePage() {
       {isEmpty ? (
         <div className="flex flex-col items-center">
           <HeaderWithBack
-            title={data?.applicationFormId || "과외 일정"}
+            title={target?.applicationFormId || "과외 일정"}
             mainClassName="pt-8"
           >
             <SessionSchedule
               className="mb-24"
               title={`Y-edu 에게 진행 중인\n과외 일정을 알려주세요`}
+              classMatchingId={target?.classMatchingId}
               token={token ?? ""}
             />
           </HeaderWithBack>
@@ -49,7 +81,7 @@ export default function SessionCompletePage() {
       ) : (
         <div className="flex w-full flex-col items-center">
           <HeaderWithBack
-            title={sessionData ? formatDateShort(sessionData) : "과외 완료"}
+            title={titleDate}
             hasBack
             onBack={onClickBack}
             mainClassName="pt-8 w-full px-5"

--- a/app/(route)/(teacher)/teacher/session-complete/page.tsx
+++ b/app/(route)/(teacher)/teacher/session-complete/page.tsx
@@ -47,7 +47,13 @@ export default function SessionCompletePage() {
     }
   }
 
-  const titleDate = cachedDate ? formatDateShort(cachedDate) : "과외 완료";
+  const titleDate = classSessionId
+    ? cachedDate
+      ? formatDateShort(cachedDate)
+      : "과외 완료"
+    : sessionData
+      ? formatDateShort(sessionData)
+      : "과외 완료";
 
   const onClickBack = () => {
     router.push(`/teacher/session-schedule?token=${token}`);

--- a/app/(route)/(teacher)/teacher/session-schedule/page.tsx
+++ b/app/(route)/(teacher)/teacher/session-schedule/page.tsx
@@ -24,7 +24,7 @@ export default function TeacherSessionScheduleListPage() {
 
   const tabs = Object.entries(data!.schedules).map(([classId, sessions]) => ({
     trigger: classId,
-    content: <SessionList sessions={sessions} />,
+    content: <SessionList classId={classId} sessions={sessions} />,
   }));
 
   return (

--- a/app/actions/get-schedules/index.ts
+++ b/app/actions/get-schedules/index.ts
@@ -1,6 +1,5 @@
 import { httpService } from "@/utils/httpService";
-
-import { DayOfWeek } from "../get-teacher-detail";
+import { DayOfWeek } from "@/actions/get-teacher-detail";
 
 export interface ClassTimeDTO {
   start: string;

--- a/app/actions/get-schedules/index.ts
+++ b/app/actions/get-schedules/index.ts
@@ -6,10 +6,14 @@ export interface ClassTimeDTO {
   classMinute: number;
 }
 
-export interface SchedulesResponse {
+export interface ScheduleItem {
   applicationFormId: string;
+  classMatchingId: number;
+  send: boolean;
   schedules: Partial<Record<DayOfWeek, ClassTimeDTO[]>>;
 }
+
+export type SchedulesResponse = ScheduleItem[];
 
 export async function getSchedules({ token }: { token: string }) {
   const res = await httpService.get<SchedulesResponse>(

--- a/app/actions/put-schedules/index.ts
+++ b/app/actions/put-schedules/index.ts
@@ -7,7 +7,8 @@ export interface ScheduleDTO {
 }
 
 export interface SchedulesRequestProps {
-  token: string;
+  token?: string;
+  classMatchingId?: number;
   schedules: ScheduleDTO[];
 }
 
@@ -27,10 +28,11 @@ export interface SchedulesResponse {
 }
 
 export async function putSchedules(props: SchedulesRequestProps) {
-  const { token, schedules } = props;
+  const { token, classMatchingId, schedules } = props;
 
   await httpService.put<SchedulesResponse>("/schedules", {
     token,
+    classMatchingId,
     schedules,
   });
 }

--- a/app/components/teacher/Session/SessionSchedule.tsx
+++ b/app/components/teacher/Session/SessionSchedule.tsx
@@ -20,13 +20,20 @@ import {
 
 export interface SessionScheduleProps {
   title: string;
-  token: string;
+  token?: string;
+  classMatchingId?: number;
   className?: string;
   initialSchedules?: Schedule[];
 }
 
 export default function SessionSchedule(props: SessionScheduleProps) {
-  const { title, className = "", token, initialSchedules = [] } = props;
+  const {
+    title,
+    className = "",
+    token,
+    classMatchingId,
+    initialSchedules = [],
+  } = props;
   const {
     selectedDays,
     toggleDay,
@@ -40,7 +47,7 @@ export default function SessionSchedule(props: SessionScheduleProps) {
     sortedSelectedDays,
     handleSubmit,
     isScheduleValid,
-  } = useSessionSchedule({ token, initialSchedules });
+  } = useSessionSchedule({ token, classMatchingId, initialSchedules });
   const [isTimePickerOpen, setIsTimePickerOpen] = useState(false);
 
   const handleOpenTimePicker = (day: string) => {

--- a/app/components/teacher/SessionList/index.tsx
+++ b/app/components/teacher/SessionList/index.tsx
@@ -13,10 +13,11 @@ import { useSessionList, SessionItem } from "./useSessionList";
 import Calender from "public/images/calendar.svg";
 
 interface SessionListProps {
+  classId: string;
   sessions: SessionResponse[];
 }
 
-export default function SessionList({ sessions }: SessionListProps) {
+export default function SessionList({ classId, sessions }: SessionListProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
   const token = searchParams.get("token");
@@ -44,7 +45,11 @@ export default function SessionList({ sessions }: SessionListProps) {
             <Image src={Calender} width={20} height={20} alt="calender" />
           }
           className="text-grey-700 w-fit cursor-pointer justify-normal gap-1 bg-transparent px-3 py-[6px] text-sm"
-          onClick={() => router.push(`/teacher/session-change?token=${token}`)}
+          onClick={() =>
+            router.push(
+              `/teacher/session-change?token=${token}&classid=${classId}`,
+            )
+          }
         >
           전체 일정 변경
         </Button>

--- a/app/hooks/mutation/usePatchSessions.ts
+++ b/app/hooks/mutation/usePatchSessions.ts
@@ -55,7 +55,7 @@ export function useSessionMutations() {
 
   const completeMutation = useMutation({
     mutationFn: patchSessionComplete,
-    onSuccess: async (data, variables: CompleteSessionVariables) => {
+    onSuccess: async (_data, variables: CompleteSessionVariables) => {
       const { token, classSessionId, date } = variables;
       if (token) {
         await queryClient.invalidateQueries({

--- a/app/hooks/mutation/usePutSchedules.ts
+++ b/app/hooks/mutation/usePutSchedules.ts
@@ -1,10 +1,15 @@
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 import { putSchedules } from "@/actions/put-schedules";
 
 export function usePutSchedules() {
+  const queryClient = useQueryClient();
+
   return useMutation({
     mutationFn: putSchedules,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["schedules"] });
+    },
     onError: (error: unknown) => {
       if (error instanceof Error) {
         alert("스케줄 등록 중 문제가 발생했어요. 다시 시도해주세요.");

--- a/app/hooks/query/useGetSchedules.ts
+++ b/app/hooks/query/useGetSchedules.ts
@@ -8,5 +8,6 @@ export function useGetSchedules({ token }: { token: string }) {
     queryFn: () => getSchedules({ token }),
     staleTime: 1000 * 60 * 60,
     gcTime: 1000 * 60 * 60 * 24,
+    throwOnError: true,
   });
 }


### PR DESCRIPTION
## 🐈 PR 요약
> PR 내용 한 줄로 요약
- 관련 테크스펙 링크 : -

## ✨ PR 상세
> PR 상세 내용 개조식으로 작성

- 각 과외건 탭에서 전체일정 수정 페이지로 넘어갈 때 해당 탭(classId)를 searchParam으로 넘기도록 수정
- api 스펙 변경에 따른 코드 수정 (classMatchingId로 put 할 수 있도록)
- 전체 일정 변경 페이지 각 탭별 데이터 받아오고, 각 탭별 데이터 수정할 수 있도록 코드 수정
- 과외완료 페이지 진입 시 날짜 표시 수정

## 🚨 참고사항
> 리뷰어들이 알아야 하거나 알면 좋은 참고사항 작성

- api 스펙 수정에 따라 classMatchingId를 기반으로 전체 과외 일정 수정할 수 잇도록 했습니다.
- 전체 과외 일정 페이지 진입시에도 classMatchingId기반으로 각 탭별 데이터 받아올 수 있도록 했습니다.

- 과외완료 페이지 진입 시 날짜가 토큰기반 api를 사용하다보니 해당 토큰이 발급된 건에 대한 날짜를 가져오는 문제가 있습니다. 때문에 해당 토큰이 발급된 과외가 아닌 다른 날짜 (예를들면 이미 지난 날짜인데 아직 완료안한 건) 을 완료시키려 하면 날짜가 다르게 표시됩니다. api스펙을 변경해서 classSessionId로 날짜 가져오게 부탁드릴까 했는데 일단 프론트에서도 할수있는 방법은 있어서 이전에 전체 과외일정 불러오는 데이터에서 캐시된 것을 가져오는 방식으로 코드 짜봤습니다. 이 부분에대해서 의견 주시면 좋을 것 같아요!

## 📸 스크린샷
> 화면 캡쳐 이미지

<img width="786" alt="스크린샷 2025-05-16 오전 11 52 50" src="https://github.com/user-attachments/assets/c66de52f-46ab-459d-8c1a-822519d22b4a" />

https://github.com/user-attachments/assets/f3828214-83b2-4a72-a801-8dcf175b6c7a

## ✅ 체크리스트
- [x] Reviewers 태그했나요?
- [x] Label 지정했나요?
- [ ] 관련 테크스펙 링크 연결했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **신규 기능**
  - 세션 변경 및 일정 목록 화면에서 URL에 포함된 classid 파라미터를 인식하여 동적으로 제목을 표시합니다.
  - "전체 일정 변경" 버튼 클릭 시 classid가 포함된 경로로 이동하도록 개선되었습니다.
  - 세션 완료 화면에서 캐시된 데이터를 활용해 제목과 날짜를 표시합니다.
  - 일정 수정 시 classMatchingId를 포함한 새로운 스케줄 관리 기능이 추가되었습니다.
  - 일정 업데이트 후 자동으로 최신 데이터를 반영하도록 캐시 무효화 기능이 도입되었습니다.

- **버그 수정**
  - 뒤로가기 버튼이 토큰 파라미터를 유지하며 세션 일정 화면으로 이동하도록 동작이 명확해졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->