### PR TITLE
fix: 과외완료 시 뜨는 toase 날짜를 Header title에서 가져오도록 코드 수정

### DIFF
--- a/app/(route)/(teacher)/teacher/session-complete/page.tsx
+++ b/app/(route)/(teacher)/teacher/session-complete/page.tsx
@@ -95,7 +95,7 @@ export default function SessionCompletePage() {
             <SessionComplete
               token={token ?? ""}
               classSessionId={classSessionId || ""}
-              date={sessionData || ""}
+              date={titleDate}
             />
           </HeaderWithBack>
         </div>

--- a/app/components/teacher/Session/SessionComplete.tsx
+++ b/app/components/teacher/Session/SessionComplete.tsx
@@ -8,7 +8,6 @@ import Radio from "@/ui/Radio";
 import Textarea from "@/ui/Textarea";
 import TitleSection from "@/ui/TitleSection";
 import Button from "@/ui/Button";
-import { formatDateShort } from "@/utils/getDayOfWeek";
 
 interface SessionCompleteProps {
   token: string;
@@ -37,7 +36,7 @@ export default function SessionComplete({
       classSessionId,
       homeworkPercentage,
       understanding: understanding.trim(),
-      date: formatDateShort(date),
+      date,
     });
   };
 

--- a/app/hooks/mutation/usePatchSessions.ts
+++ b/app/hooks/mutation/usePatchSessions.ts
@@ -56,7 +56,7 @@ export function useSessionMutations() {
   const completeMutation = useMutation({
     mutationFn: patchSessionComplete,
     onSuccess: async (_data, variables: CompleteSessionVariables) => {
-      const { token, classSessionId, date } = variables;
+      const { token, classSessionId } = variables;
       if (token) {
         await queryClient.invalidateQueries({
           queryKey: ["schedules", token],
@@ -68,7 +68,7 @@ export function useSessionMutations() {
         });
       }
       router.push(`/teacher/session-schedule?token=${token ?? ""}`);
-      toast.success(`${date} 과외가 완료되었어요`);
+      toast.success(`${variables.date} 과외가 완료되었어요`);
     },
   });
 


### PR DESCRIPTION
## 🐈 PR 요약
> PR 내용 한 줄로 요약
- 관련 테크스펙 링크 : -

## ✨ PR 상세
> PR 상세 내용 개조식으로 작성

- 과외 완료 버튼 클릭시 뜨는 toast의 날짜 데이터를 headerWithBack title과 일치시켰습니다.

## 🚨 참고사항
> 리뷰어들이 알아야 하거나 알면 좋은 참고사항 작성

- 현재 과외 완료 페이지에는 두 가지 진입 경로가 있습니다. 하나는 알림톡 링크로 진입할 때(링크에 token만 있는 경우)이고,
다른 하나는 과외 스케줄 리스트에서 사용자가 특정 세션을 선택해 들어갈 때(링크에 token과 sessionId가 있는 경우)입니다. 

- 첫 번째 경우에는 API(useGetSessionByToken)로 받아온 날짜를, 두 번째 경우에는 React Query 캐시에서 해당 sessionId에 매칭되는 classDate를 꺼내 사용하도록 했습니다. 이렇게 얻은 날짜를 HeaderWithBack 타이틀과 완료 시 띄우는 toast.success() 메시지에 동일하게 적용함으로써, 두 경로에서 날짜가 불일치하던 문제를 해결했습니다.

- 그런데 막상 하고보니 뭔가 편법으로 해결한 느낌도 있긴 합니다.. 편법인가 문제해결인가 애매하네요 ㅋㅋ

## 📸 스크린샷
> 화면 캡쳐 이미지

https://github.com/user-attachments/assets/745204bc-4f2c-4966-802e-ac534569a693

## ✅ 체크리스트
- [x] Reviewers 태그했나요?
- [x] Label 지정했나요?
- [ ] 관련 테크스펙 링크 연결했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 과외 완료 화면에서 날짜 표시 형식과 소스가 개선되어, 이제 더 일관된 형식의 날짜 또는 기본 문구("과외 완료")가 표시됩니다.
  - 완료 알림 메시지에서 날짜가 올바르게 표시되도록 처리 방식을 수정하였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->