### PR TITLE
fix: 탭 x축 스크롤 시 왼쪽 마진값이 0이 되어버리는 오류 해결

### DIFF
--- a/app/(route)/(teacher)/teacher/session-schedule/page.tsx
+++ b/app/(route)/(teacher)/teacher/session-schedule/page.tsx
@@ -35,7 +35,7 @@ export default function TeacherSessionScheduleListPage() {
           tabs={tabs}
           paramKey="classId"
           listClassName="overflow-x-auto whitespace-nowrap scrollbar-hide"
-          buttonClassName="flex-initial px-[10px]"
+          buttonClassName="flex-initial px-[10px] scroll-ml-5"
         />
       </HeaderWithBack>
     </ErrorBoundary>

--- a/app/ui/Bar/TabBar.tsx
+++ b/app/ui/Bar/TabBar.tsx
@@ -93,6 +93,7 @@ export default function TabBar({
             }}
             className={cn(
               "flex-1 border-b-2 border-transparent py-[10px] text-center font-[500] leading-[146%] tracking-[-0.02em] text-grey-500",
+              "scroll-ml-5",
               selectedTab === tab.trigger &&
                 "border-primaryNormal font-bold text-primaryNormal",
               buttonClassName,

--- a/app/ui/Bar/TabBar.tsx
+++ b/app/ui/Bar/TabBar.tsx
@@ -93,7 +93,6 @@ export default function TabBar({
             }}
             className={cn(
               "flex-1 border-b-2 border-transparent py-[10px] text-center font-[500] leading-[146%] tracking-[-0.02em] text-grey-500",
-              "scroll-ml-5",
               selectedTab === tab.trigger &&
                 "border-primaryNormal font-bold text-primaryNormal",
               buttonClassName,


### PR DESCRIPTION
## 🐈 PR 요약
> PR 내용 한 줄로 요약
- 관련 테크스펙 링크 : - 

## ✨ PR 상세
> PR 상세 내용 개조식으로 작성

- 탭바가 x축으로 자동 스크롤될 때 왼쪽 마진 20px > 0 으로 되어버리는 문제 해결 

## 🚨 참고사항
> 리뷰어들이 알아야 하거나 알면 좋은 참고사항 작성

## 📸 스크린샷
> 화면 캡쳐 이미지

## ✅ 체크리스트
- [x] Reviewers 태그했나요?
- [x] Label 지정했나요?
- [ ] 관련 테크스펙 링크 연결했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - 탭 버튼에 좌측 스크롤 마진이 추가되어 스크롤 시 시각적 간격이 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->