### PR TITLE
fix: 과외 완료 오류 수정

### DIFF
--- a/app/actions/get-session-by-token/index.ts
+++ b/app/actions/get-session-by-token/index.ts
@@ -3,6 +3,11 @@ import { httpService } from "@/utils/httpService";
 export interface SessionByTokenResponse {
   sessionDate: string;
   isComplete: boolean;
+  teacherId: number;
+  classTime: {
+    start: string;
+    classMinute: number;
+  };
 }
 
 export async function getSessionByToken({

--- a/app/components/teacher/Session/SessionComplete.tsx
+++ b/app/components/teacher/Session/SessionComplete.tsx
@@ -26,6 +26,7 @@ export default function SessionComplete({
     null,
   );
   const [understanding, setUnderstanding] = useState("");
+
   const { completeMutation } = useSessionMutations();
   const isFormValid =
     homeworkPercentage !== null && understanding.trim().length > 0;
@@ -36,6 +37,7 @@ export default function SessionComplete({
     mixpanelTrack("수업 리뷰 전송", {
       homeworkPercentage,
       understanding: understanding.trim(),
+      submitTime: Date.now(),
     });
 
     completeMutation.mutate({

--- a/app/utils/mixpanel.ts
+++ b/app/utils/mixpanel.ts
@@ -22,3 +22,41 @@ export const mixpanelTrack = (
     window.mixpanel.track(event, properties);
   }
 };
+
+export const mixpanelIdentify = (userId: string) => {
+  if (typeof window !== "undefined" && window.mixpanel?.identify) {
+    window.mixpanel.identify(userId);
+  }
+};
+
+export const mixpanelSetPeople = (props: Record<string, unknown>) => {
+  if (typeof window !== "undefined" && window.mixpanel?.people?.set) {
+    window.mixpanel.people.set(props);
+  }
+};
+// 수업종료시간 == 알림톡전송시간 계산
+export function calculateSessionEndTime(
+  start: string,
+  duration: number,
+): string {
+  const [hourStr, minuteStr] = start.split(":");
+  let hour = Number(hourStr);
+  let minute = Number(minuteStr);
+
+  minute += duration;
+  if (minute >= 60) {
+    hour += Math.floor(minute / 60);
+    minute %= 60;
+  }
+
+  const now = new Date();
+  const dateWithTime = new Date(
+    now.getFullYear(),
+    now.getMonth(),
+    now.getDate(),
+    hour,
+    minute,
+  );
+
+  return dateWithTime.toISOString();
+}


### PR DESCRIPTION
## 🐈 PR 요약
> 과외 일정 완료 오류 hotfix, 믹스패널 사용자 id 부여
- 관련 테크스펙 링크 : 

## ✨ PR 상세
> 한번 과외를 완료하면 다른 과외일정 완료가 안되는 문제를 발견했습니다.

기존 session-complete 페이지 로직에서  if (!sessionData?.isComplete) return; 으로 과외완료여부를 판별하고 있었는데,
이 sessionData가 토큰 기반의 데이터라 데이터 불일치 문제가 생긴거였어요. 
sessionId가 param에 있을 경우 데이터를 갈아끼우도록 변경하였습니다.

## 🚨 참고사항
> 리뷰어들이 알아야 하거나 알면 좋은 참고사항 작성

## 📸 스크린샷
> 화면 캡쳐 이미지

## ✅ 체크리스트
- [ ] Reviewers 태그했나요?
- [ ] Label 지정했나요?
- [ ] 관련 테크스펙 링크 연결했나요?
