### PR TITLE
fix: 스케줄 없을 경우 버그 수정, 토큰 무효시 리다이렉트 추가

### DIFF
--- a/app/(route)/(teacher)/teacher/session-complete/page.tsx
+++ b/app/(route)/(teacher)/teacher/session-complete/page.tsx
@@ -79,11 +79,11 @@ export default function SessionCompletePage() {
   const goToSchedulePage = (classId?: string) => {
     const params = new URLSearchParams(searchParams.toString());
     params.delete("sessionId");
-    router.push(`/teacher/session-schedule?${params.toString()}`);
     if (classId)
       router.push(
         `/teacher/session-schedule?${params.toString()}&classId=${classId}`,
       );
+    else router.push(`/teacher/session-schedule?${params.toString()}`);
   };
 
   useEffect(() => {

--- a/app/(route)/(teacher)/teacher/session-complete/page.tsx
+++ b/app/(route)/(teacher)/teacher/session-complete/page.tsx
@@ -43,33 +43,31 @@ export default function SessionCompletePage() {
     : null;
 
   const activeSessionData = useMemo(() => {
-    return sessionFromCache
-      ? {
-          isComplete: sessionFromCache.complete,
-          classTime: {
-            start: sessionFromCache.classStart,
-            classMinute: sessionFromCache.classMinute,
-          },
-          sessionDate: sessionFromCache.classDate,
-          teacherId: sessionByToken?.teacherId,
-        }
-      : sessionByToken;
+    if (sessionFromCache) {
+      return {
+        isComplete: sessionFromCache.complete,
+        classTime: {
+          start: sessionFromCache.classStart,
+          classMinute: sessionFromCache.classMinute,
+        },
+        sessionDate: sessionFromCache.classDate,
+        teacherId: sessionByToken?.teacherId,
+      };
+    }
+
+    if (sessionByToken?.sessionDate) {
+      return sessionByToken;
+    }
+
+    return null;
   }, [sessionFromCache, sessionByToken]);
 
-  const titleDate = sessionFromCache?.classDate
-    ? formatDateShort(sessionFromCache.classDate)
-    : activeSessionData?.sessionDate
-      ? formatDateShort(activeSessionData.sessionDate)
-      : "과외 완료";
-
-  const onClickBack = () => {
-    const params = new URLSearchParams(searchParams.toString());
-    params.delete("sessionId");
-    router.push(`/teacher/session-schedule?${params.toString()}`);
-  };
+  const titleDate = activeSessionData?.sessionDate
+    ? formatDateShort(activeSessionData.sessionDate)
+    : "과외 완료";
 
   const endTime = useMemo(() => {
-    if (activeSessionData && !activeSessionData.isComplete) {
+    if (activeSessionData?.classTime) {
       return calculateSessionEndTime(
         activeSessionData.classTime.start,
         activeSessionData.classTime.classMinute,
@@ -78,14 +76,27 @@ export default function SessionCompletePage() {
     return "";
   }, [activeSessionData]);
 
-  useEffect(() => {
-    if (!activeSessionData?.isComplete) return;
-
+  const goToSchedulePage = (classId?: string) => {
     const params = new URLSearchParams(searchParams.toString());
     params.delete("sessionId");
     router.push(`/teacher/session-schedule?${params.toString()}`);
-    toast.success("이미 리뷰 작성을 완료한 수업입니다");
-  }, [activeSessionData, token, router, searchParams, toast]);
+    if (classId)
+      router.push(
+        `/teacher/session-schedule?${params.toString()}&classId=${classId}`,
+      );
+  };
+
+  useEffect(() => {
+    if (isEmpty) return;
+
+    // 일정변경된 과외건인 경우
+    if (!activeSessionData) goToSchedulePage(target?.applicationFormId);
+
+    if (activeSessionData?.isComplete) {
+      goToSchedulePage(target?.applicationFormId);
+      toast.success("이미 리뷰 작성을 완료한 수업입니다");
+    }
+  }, [activeSessionData, searchParams, isEmpty]);
 
   useEffect(() => {
     if (!activeSessionData) return;
@@ -103,7 +114,7 @@ export default function SessionCompletePage() {
     }
   }, [activeSessionData]);
 
-  if (isLoading) {
+  if (isLoading || (!activeSessionData && !isEmpty)) {
     return (
       <div className="flex min-h-screen items-center justify-center">
         <CircularProgress />
@@ -133,7 +144,7 @@ export default function SessionCompletePage() {
           <HeaderWithBack
             title={titleDate}
             hasBack
-            onBack={onClickBack}
+            onBack={goToSchedulePage}
             mainClassName="pt-8 w-full px-5"
           >
             <SessionComplete


### PR DESCRIPTION
## 🐈 PR 요약
> 스케줄 없을 경우 버그 수정, 로직 수정
- 관련 테크스펙 링크 : 

## ✨ PR 상세
> 스케줄 없을 경우 버그 수정

스케줄이 없을경우 activeSessindData의 속성들이 null이 되면서 에러가 발생했었습니다. 이에 객체를 null로 처리하고 분기처리하도록 변경하였습니다.

> 스케줄 없을 경우 토큰 재접근 시 /session-schedule 리다이렉트

스케줄 없을 경우 알림톡에 재접근 시 토큰이 무효화되어 에러페이지가 났습니다. 스케줄이 등록되어있고, 해당 토큰의 과외 정보가 없는 경우 /session-schedule로 리다이렉트 되도록 추가하였습니다.

> 스케줄 등록 후, 이미 리뷰작성된 경우 /session-schedule 리다이렉트될때 해당 과외탭으로 이동

해당 수업탭으로 이동되도록 변경하였습니다.

## 🚨 참고사항
> 리뷰어들이 알아야 하거나 알면 좋은 참고사항 작성

## 📸 스크린샷
> 화면 캡쳐 이미지

## ✅ 체크리스트
- [x] Reviewers 태그했나요?
- [x] Label 지정했나요?
- [ ] 관련 테크스펙 링크 연결했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 세션 데이터가 없거나 일정이 비어 있을 때 스케줄 페이지로 자동 이동하도록 개선되었습니다.
  - 이미 완료된 세션의 경우, 리뷰가 완료되었음을 알리는 안내 메시지가 표시됩니다.

- **개선 사항**
  - 세션 정보와 일정 변경에 따른 화면 전환 및 로딩 처리 로직이 더욱 명확해졌습니다.
  - 뒤로 가기 버튼이 개선되어 스케줄 페이지로 더 안전하게 이동합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->