### PR TITLE
feat: 믹스패널 리뷰 전송 이벤트 속성 추가

### DIFF
--- a/app/(route)/(teacher)/teacher/session-complete/page.tsx
+++ b/app/(route)/(teacher)/teacher/session-complete/page.tsx
@@ -151,6 +151,7 @@ export default function SessionCompletePage() {
               token={token ?? ""}
               classSessionId={classSessionId || ""}
               date={titleDate}
+              endTime={endTime}
             />
           </HeaderWithBack>
         </div>

--- a/app/components/teacher/Session/SessionComplete.tsx
+++ b/app/components/teacher/Session/SessionComplete.tsx
@@ -15,12 +15,14 @@ interface SessionCompleteProps {
   token: string;
   classSessionId: string;
   date: string;
+  endTime: string;
 }
 
 export default function SessionComplete({
   token,
   date,
   classSessionId,
+  endTime,
 }: SessionCompleteProps) {
   const [homeworkPercentage, setHomeworkPercentage] = useState<number | null>(
     null,
@@ -34,10 +36,18 @@ export default function SessionComplete({
   const handleComplete = () => {
     if (!isFormValid || homeworkPercentage === null) return;
 
+    const submitTime = new Date();
+    const classEndTime = new Date(endTime);
+
     mixpanelTrack("수업 리뷰 전송", {
       homeworkPercentage,
       understanding: understanding.trim(),
-      submitTime: Date.now(),
+      submitTime: submitTime.toISOString(),
+      endTime,
+      timeToSubmit: Math.floor(
+        (submitTime.getTime() - classEndTime.getTime()) / 1000 / 60,
+      ),
+      isSubmittedSameDay: submitTime.getDate() === classEndTime.getDate(),
     });
 
     completeMutation.mutate({


### PR DESCRIPTION
## 🐈 PR 요약
> 리뷰 전송 이벤트에 속성 추가
- 관련 테크스펙 링크 : 

## ✨ PR 상세
> 시간 속성들끼리 믹스패널에서 계산하려고 했었는데, 따로 있는 이벤트끼리는 계산이 안되고, 속성추가가 원활히 되지 않아서 코드상에서 추가했습니다.

## 🚨 참고사항
> 데이터수집코드가 섞이는 것이 약간 불편하네요..

## 📸 스크린샷
> 화면 캡쳐 이미지

## ✅ 체크리스트
- [ ] Reviewers 태그했나요?
- [ ] Label 지정했나요?
- [ ] 관련 테크스펙 링크 연결했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 세션 완료 화면에서 수업 종료 시간 정보를 추가로 표시합니다.

- **버그 수정**
  - 세션 리뷰 전송 시 제출 시간과 수업 종료 시간 간의 차이 및 동일 일자 제출 여부가 정확하게 기록됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->