### PR TITLE
fix:링크에 토큰만 있는 과외완료 페이지에서 뒤로가기 버튼 클릭 시 탭 지정 안되는 오류 해결

### DIFF
--- a/app/(route)/(teacher)/teacher/session-complete/page.tsx
+++ b/app/(route)/(teacher)/teacher/session-complete/page.tsx
@@ -144,7 +144,7 @@ export default function SessionCompletePage() {
           <HeaderWithBack
             title={titleDate}
             hasBack
-            onBack={goToSchedulePage}
+            onBack={() => goToSchedulePage(target?.applicationFormId)}
             mainClassName="pt-8 w-full px-5"
           >
             <SessionComplete


### PR DESCRIPTION
## 🐈 PR 요약
> PR 내용 한 줄로 요약
- 관련 테크스펙 링크 : -

## ✨ PR 상세
> PR 상세 내용 개조식으로 작성

- 알림톡에서 진입한 토큰만 존재하는 과외완료 페이지에서 뒤로가기 버튼 클릭할 경우, 탭이 지정되지 않아 스케줄 렌더링이 되지 않는 문제 해결

## 🚨 참고사항
> 리뷰어들이 알아야 하거나 알면 좋은 참고사항 작성

- onClick 에 바로 goToSchedulePage 함수를 넘겨서 생긴 문제로, 화살표 함수로 바꾸고 인자를 target.applicationFormId로 넣어 해결해
했습니다.

## 📸 스크린샷
> 화면 캡쳐 이미지

<img width="378" alt="스크린샷 2025-06-01 오후 3 23 46" src="https://github.com/user-attachments/assets/0cf2955f-ca2c-4aa0-87c7-905c3a48aaa9" />

<img width="379" alt="스크린샷 2025-06-01 오후 3 24 01" src="https://github.com/user-attachments/assets/f6752241-1ef8-403c-8e16-6d871aea0fab" />



## ✅ 체크리스트
- [x] Reviewers 태그했나요?
- [x] Label 지정했나요?
- [ ] 관련 테크스펙 링크 연결했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 세션 완료 페이지에서 뒤로 가기 버튼이 올바른 신청서 ID를 포함하여 일정 페이지로 이동하도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->