### PR TITLE
Fix/byunghoon ut : 3차 페이지네이션 적용 및 무한 스크롤 구현, 

### DIFF
--- a/app/(route)/(teacher)/teacher/session-complete/page.tsx
+++ b/app/(route)/(teacher)/teacher/session-complete/page.tsx
@@ -27,7 +27,7 @@ export default function SessionCompletePage() {
   const token = searchParams.get("token") ?? "";
   const classSessionId = searchParams.get("sessionId");
 
-  const { data: sessions } = useGetSessions(token);
+  const { data: sessions } = useGetSessions(token, 0, 3);
   const { data, isLoading } = useGetSchedules({ token });
   const { data: sessionByToken } = useGetSessionByToken({ token: token ?? "" });
 

--- a/app/(route)/(teacher)/teacher/session-review/page.tsx
+++ b/app/(route)/(teacher)/teacher/session-review/page.tsx
@@ -17,8 +17,10 @@ export default function SessionReviewPage() {
   const token = searchParams.get("token") ?? "";
   const sessionIdStr = searchParams.get("sessionId") ?? "";
   const sessionId = Number(sessionIdStr);
+  const classId = searchParams.get("classId")!;
+  const isComplete = searchParams.get("is-complete") === "true";
 
-  const { data, isLoading } = useGetSessions(token);
+  const { data, isLoading } = useGetSessions(token, 0, 20, isComplete, classId);
 
   const targetSession = useMemo(() => {
     if (!data) return undefined;

--- a/app/(route)/(teacher)/teacher/session-schedule/page.tsx
+++ b/app/(route)/(teacher)/teacher/session-schedule/page.tsx
@@ -25,14 +25,10 @@ export default function TeacherSessionScheduleListPage() {
     );
   }
 
-  const tabs = Object.entries(data!.schedules).map(
-    ([classId, schedulePage]) => ({
-      trigger: classId,
-      content: (
-        <SessionList classId={classId} sessions={schedulePage.content} />
-      ),
-    }),
-  );
+  const tabs = Object.keys(data!.schedules).map((classId) => ({
+    trigger: classId,
+    content: <SessionList classId={classId} />,
+  }));
 
   return (
     <ErrorBoundary fallback={<ErrorUI />}>

--- a/app/(route)/(teacher)/teacher/session-schedule/page.tsx
+++ b/app/(route)/(teacher)/teacher/session-schedule/page.tsx
@@ -13,7 +13,7 @@ import TabBar from "@/ui/Bar/TabBar";
 export default function TeacherSessionScheduleListPage() {
   const searchParams = useSearchParams();
   const token = searchParams.get("token") ?? "";
-  const { data, isLoading } = useGetSessions(token);
+  const { data, isLoading } = useGetSessions(token, 0, 3);
 
   const currentMonth = new Date().getMonth() + 1;
 

--- a/app/(route)/(teacher)/teacher/session-schedule/page.tsx
+++ b/app/(route)/(teacher)/teacher/session-schedule/page.tsx
@@ -27,7 +27,7 @@ export default function TeacherSessionScheduleListPage() {
 
   const tabs = Object.keys(data!.schedules).map((classId) => ({
     trigger: classId,
-    content: <SessionList classId={classId} />,
+    content: <SessionList key={classId} classId={classId} />,
   }));
 
   return (

--- a/app/actions/post-getSessions/index.ts
+++ b/app/actions/post-getSessions/index.ts
@@ -45,10 +45,20 @@ export interface SessionsResponse {
   schedules: Record<string, SchedulePageInfo>;
 }
 
-export const getSessions = async (token: string): Promise<SessionsResponse> => {
-  const { data } = await httpService.post<SessionsResponse>(
-    `/sessions?token=${token}`,
-    {},
-  );
+export const getSessions = async (
+  token: string,
+  page: number,
+  size: number,
+  isComplete?: boolean,
+): Promise<SessionsResponse> => {
+  const { data } = await httpService.post<SessionsResponse>("/sessions", null, {
+    params: {
+      token,
+      page,
+      size,
+      ...(isComplete !== undefined && { isComplete }),
+    },
+  });
+
   return data;
 };

--- a/app/components/teacher/SessionList/index.tsx
+++ b/app/components/teacher/SessionList/index.tsx
@@ -50,6 +50,7 @@ export default function SessionList({ classId }: SessionListProps) {
   const params = new URLSearchParams(searchParams.toString());
 
   const changeFilter = (next: boolean) => {
+    if (next === isComplete) return;
     params.set("is-complete", String(next));
     router.push(`${pathName}?${params.toString()}`);
     setIsComplete(next);
@@ -123,7 +124,7 @@ export default function SessionList({ classId }: SessionListProps) {
           정규 일정 변경
         </Button>
       </section>
-      {items.length === 0 ? (
+      {isInitialLoading || isFetching ? null : items.length === 0 ? (
         <div className="text-center text-gray-500">조회된 일정이 없습니다.</div>
       ) : (
         items.map((session, idx) => (

--- a/app/components/teacher/SessionList/index.tsx
+++ b/app/components/teacher/SessionList/index.tsx
@@ -43,7 +43,9 @@ export default function SessionList({ classId }: SessionListProps) {
   useEffect(() => {
     if (!data) return;
     const newContent = data.schedules[classId]?.content ?? [];
-    setSessions((prev) => (page === 0 ? newContent : [...prev, ...newContent]));
+    setSessions((prev) => {
+      return page === 0 ? newContent : [...prev, ...newContent];
+    });
   }, [data, classId, page]);
 
   const items: SessionItem[] = useSessionList(sessions);
@@ -87,6 +89,7 @@ export default function SessionList({ classId }: SessionListProps) {
 
   const isInitialLoading =
     page === 0 && sessions.length === 0 && (isLoading || isFetching);
+  const hasMore = !!data?.schedules[classId] && !data.schedules[classId].last;
 
   if (isInitialLoading) {
     return (
@@ -124,7 +127,7 @@ export default function SessionList({ classId }: SessionListProps) {
           정규 일정 변경
         </Button>
       </section>
-      {isInitialLoading || isFetching ? null : items.length === 0 ? (
+      {isInitialLoading ? null : items.length === 0 ? (
         <div className="text-center text-gray-500">조회된 일정이 없습니다.</div>
       ) : (
         items.map((session, idx) => (
@@ -140,7 +143,7 @@ export default function SessionList({ classId }: SessionListProps) {
           />
         ))
       )}
-      {!infiniteScroll && !data?.schedules[classId]?.last && (
+      {!isInitialLoading && items.length > 0 && !infiniteScroll && hasMore && (
         <div className="flex justify-center">
           <Button
             className="cursor-default bg-transparent py-3 text-[14px] font-semibold text-gray-700"

--- a/app/components/teacher/SessionList/index.tsx
+++ b/app/components/teacher/SessionList/index.tsx
@@ -2,11 +2,13 @@
 import { useState } from "react";
 import { useRouter, useSearchParams, usePathname } from "next/navigation";
 import Image from "next/image";
+import { CircularProgress } from "@mui/material";
 
 import SessionListCard from "@/ui/Card/SessionListCard";
-import { SessionResponse } from "@/actions/post-getSessions";
+import { useGetSessions } from "@/hooks/query/useGetSessions";
 import Chip from "@/ui/Chip";
 import Button from "@/ui/Button";
+import IconDown from "@/icons/IconDown";
 
 import { useSessionList, SessionItem } from "./useSessionList";
 
@@ -14,26 +16,35 @@ import Calender from "public/images/calendar.svg";
 
 interface SessionListProps {
   classId: string;
-  sessions: SessionResponse[];
 }
 
-export default function SessionList({ classId, sessions }: SessionListProps) {
+export default function SessionList({ classId }: SessionListProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
   const pathName = usePathname();
-  const showParam = searchParams.get("show-completed");
+  const token = searchParams.get("token") ?? "";
+  const showParam = searchParams.get("is-complete");
   const initialShow = showParam === "true";
-  const items: SessionItem[] = useSessionList(sessions);
-  const [showCompleted, setShowCompleted] = useState(initialShow);
-  const filtered = items.filter((item) => item.complete === showCompleted);
+  const [isComplete, setIsComplete] = useState(initialShow);
 
+  const { data, isLoading } = useGetSessions(token, 0, 3, isComplete);
+
+  const sessionsData = data?.schedules[classId]?.content ?? [];
+  const items: SessionItem[] = useSessionList(sessionsData);
   const params = new URLSearchParams(searchParams.toString());
-
   const changeFilter = (next: boolean) => {
-    params.set("show-completed", String(next));
+    params.set("is-complete", String(next));
     router.push(`${pathName}?${params.toString()}`);
-    setShowCompleted(next);
+    setIsComplete(next);
   };
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-10">
+        <CircularProgress />
+      </div>
+    );
+  }
 
   return (
     <div className="min-h-screen space-y-3 bg-gray-50 px-5 py-4">
@@ -41,12 +52,12 @@ export default function SessionList({ classId, sessions }: SessionListProps) {
         <div className="flex gap-2">
           <Chip
             chipText="미완료"
-            isSelected={!showCompleted}
+            isSelected={!isComplete}
             onClick={() => changeFilter(false)}
           />
           <Chip
             chipText="완료"
-            isSelected={showCompleted}
+            isSelected={isComplete}
             onClick={() => changeFilter(true)}
           />
         </div>
@@ -63,10 +74,10 @@ export default function SessionList({ classId, sessions }: SessionListProps) {
           정규 일정 변경
         </Button>
       </section>
-      {filtered.length === 0 ? (
+      {items.length === 0 ? (
         <div className="text-center text-gray-500">조회된 일정이 없습니다.</div>
       ) : (
-        filtered.map((session, idx) => (
+        items.map((session, idx) => (
           <SessionListCard
             classSessionId={session.id}
             key={session.id}
@@ -79,6 +90,14 @@ export default function SessionList({ classId, sessions }: SessionListProps) {
           />
         ))
       )}
+      <div className="flex justify-center">
+        <Button className="cursor-default bg-transparent py-3 text-[14px] font-semibold text-gray-700">
+          <span className="flex cursor-pointer items-center">
+            더보기
+            <IconDown className="ml-1 size-5" IconColor="#374151" />
+          </span>
+        </Button>
+      </div>
     </div>
   );
 }

--- a/app/hooks/mutation/usePatchSessions.ts
+++ b/app/hooks/mutation/usePatchSessions.ts
@@ -98,7 +98,7 @@ export function useSessionMutations() {
       if (classId) {
         params.set("classId", classId);
       }
-      params.set("show-completed", "true");
+      params.set("is-complete", "true");
       router.push(`/teacher/session-schedule?${params.toString()}`);
 
       toast.success(`${date} 과외가 완료되었어요`);

--- a/app/hooks/query/useGetSessions.ts
+++ b/app/hooks/query/useGetSessions.ts
@@ -2,11 +2,16 @@ import { useQuery } from "@tanstack/react-query";
 
 import { getSessions } from "@/actions/post-getSessions";
 
-export function useGetSessions(token: string) {
+export function useGetSessions(
+  token: string,
+  page: number = 0,
+  size: number = 3,
+  isComplete: boolean = false,
+) {
   return useQuery({
-    queryKey: ["sessions", token],
+    queryKey: ["sessions", token, page, size, isComplete],
     queryFn: async () => {
-      const res = await getSessions(token);
+      const res = await getSessions(token, page, size, isComplete);
       return res;
     },
     staleTime: 0,

--- a/app/hooks/query/useGetSessions.ts
+++ b/app/hooks/query/useGetSessions.ts
@@ -7,9 +7,10 @@ export function useGetSessions(
   page: number = 0,
   size: number = 3,
   isComplete: boolean = false,
+  classId?: string,
 ) {
   return useQuery({
-    queryKey: ["sessions", token, page, size, isComplete],
+    queryKey: ["sessions", token, page, size, isComplete, classId],
     queryFn: async () => {
       const res = await getSessions(token, page, size, isComplete);
       return res;

--- a/app/hooks/query/useGetSessions.ts
+++ b/app/hooks/query/useGetSessions.ts
@@ -4,8 +4,8 @@ import { getSessions } from "@/actions/post-getSessions";
 
 export function useGetSessions(
   token: string,
-  page: number = 0,
-  size: number = 3,
+  page: number,
+  size: number,
   isComplete: boolean = false,
   classId?: string,
 ) {


### PR DESCRIPTION
## 🐈 PR 요약
> PR 내용 한 줄로 요약
- 관련 테크스펙 링크 : -

## ✨ PR 상세
> PR 상세 내용 개조식으로 작성

- session 조회 api 스펙 변경에 따른 코드 수정
- 더보기 버튼 추가 및 페이지네이션 추가
- 더보기 클릭 후 무한 스크롤로 동작하도록 기능 추가

## 🚨 참고사항
> 리뷰어들이 알아야 하거나 알면 좋은 참고사항 작성

- 정말,,,어려운,,과제였던 것 같아요.. 미완료, 완료 분리에 따라 리뷰보기 페이지 등 조회 api가 쓰이는 모든 영역에서 변경사항이 필요해서 좀 놓친 부분도 있는 것 같고 무한스크롤 적용도 지저분하게 된 것 같아요..추후 개선해보면 좋을 것 같습니다.

-완료/미완료건이 분리되어 각 탭을 누를 때마다 api를 불러와야해서 렌더링 초기에 깜박거리는 증상이 있는데 요건 어떻게 해결해야할지 모르겠습니다 ㅠㅠ

## 📸 스크린샷
> 화면 캡쳐 이미지

https://github.com/user-attachments/assets/fc30b975-1749-4024-9f2c-44622d01b5da

## ✅ 체크리스트
- [x] Reviewers 태그했나요?
- [x] Label 지정했나요?
- [ ] 관련 테크스펙 링크 연결했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 세션 목록에 페이지네이션과 무한 스크롤 기능이 추가되었습니다.
  - 세션 목록을 완료 여부 및 클래스별로 필터링할 수 있습니다.

- **버그 수정**
  - 세션 완료 후 URL 파라미터가 일관되게 적용되도록 수정되었습니다.

- **리팩터**
  - 세션 목록 컴포넌트가 동적으로 데이터를 가져오도록 구조가 개선되었습니다.
  - 세션 데이터 필터링이 클라이언트에서 서버 측 필터링으로 전환되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->