### PR TITLE
fix: 백엔드 sorting 변경으로 프론트 코드 제거

### DIFF
--- a/app/components/teacher/SessionList/useSessionList.ts
+++ b/app/components/teacher/SessionList/useSessionList.ts
@@ -81,11 +81,6 @@ export function useSessionList(data: SessionResponse[]): SessionItem[] {
       };
     });
 
-    return mapped.sort((a, b) => {
-      if (a.complete && b.complete) {
-        return b.date.getTime() - a.date.getTime();
-      }
-      return 0;
-    });
+    return mapped;
   }, [data]);
 }


### PR DESCRIPTION
## 🐈 PR 요약
> 세션 리스트 정렬 로직 제거
- 관련 테크스펙 링크 : 

## ✨ PR 상세
- useSessionList 훅에서 프론트엔드 정렬 로직 제거  

## 🚨 참고사항
- 클라이언트 정렬 로직이 제거되어, 일정 순서는 백엔드 API 응답에 따릅니다.

## 📸 스크린샷

## ✅ 체크리스트
- [x] Reviewers 태그했나요?  
- [x] Label 지정했나요?  
- [ ] 관련 테크스펙 링크 연결했나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 세션 목록에서 완료된 세션의 정렬이 제거되어, 세션 항목이 원래 순서대로 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->