### PR TITLE
[fix] 이미 있는 일정으로 변경하려고 할 때 막기 + 최대 너비 수정

### DIFF
--- a/app/(route)/(teacher)/layout.tsx
+++ b/app/(route)/(teacher)/layout.tsx
@@ -10,7 +10,7 @@ export default function TeacherLayout({
       <Head>
         <meta name="viewport" content="width=device-width" />
       </Head>
-      <div className="mx-auto max-w-[375px]">{children}</div>
+      <div className="mx-auto max-w-[420px]">{children}</div>
     </>
   );
 }

--- a/app/components/teacher/Session/SessionComplete.tsx
+++ b/app/components/teacher/Session/SessionComplete.tsx
@@ -162,7 +162,7 @@ export default function SessionComplete({
       </DivWithLabel>
       <div className="fixed inset-x-0 bottom-0 flex justify-center bg-white p-4 shadow-lg">
         <Button
-          className="w-[335px]"
+          className="w-[375px]"
           disabled={!isFormValid || completeMutation.isPending}
           onClick={handleComplete}
         >

--- a/app/components/teacher/Session/SessionSchedule.tsx
+++ b/app/components/teacher/Session/SessionSchedule.tsx
@@ -176,7 +176,7 @@ export default function SessionSchedule(props: SessionScheduleProps) {
       {/* 나중에 toast alert 추가하기 */}
       <div className="fixed inset-x-0 bottom-0 flex justify-center bg-white p-4 shadow-lg">
         <Button
-          className="w-[335px]"
+          className="w-[375px]"
           disabled={!isScheduleValid}
           onClick={handleSubmit}
         >

--- a/app/components/teacher/SessionList/RescheduleSheet.tsx
+++ b/app/components/teacher/SessionList/RescheduleSheet.tsx
@@ -1,11 +1,14 @@
 import { useState } from "react";
 import { format } from "date-fns";
 import { ko } from "date-fns/locale";
+import { useSearchParams } from "next/navigation";
 
 import FirstDayPicker from "@/components/result/FirstDayPicker";
 import { FirstDay } from "@/components/result/ConfirmedResult/useConfirmedResult";
 import Button from "@/ui/Button";
 import { useSessionMutations } from "@/hooks/mutation/usePatchSessions";
+import { useGetSessions } from "@/hooks/query/useGetSessions";
+import { useGlobalSnackbar } from "@/providers/GlobalSnackBar";
 
 interface RescheduleSheetProps {
   sessionId: number;
@@ -13,12 +16,18 @@ interface RescheduleSheetProps {
   time: string; // ex. 오전 5:00
   close: () => void;
 }
+
 export default function RescheduleSheet({
   sessionId,
   date,
   time,
   close,
 }: RescheduleSheetProps) {
+  const toast = useGlobalSnackbar();
+  const searchParams = useSearchParams();
+  const token = searchParams.get("token") as string;
+  const { data: allSessions } = useGetSessions(token, 0, 50);
+
   const [confirmed, setConfirmed] = useState(false);
   const [selectedDate, setSelectedDate] = useState<FirstDay>(
     convertToFirstDay(date, time),
@@ -27,7 +36,6 @@ export default function RescheduleSheet({
   const { mutate } = useSessionMutations().changeMutation;
 
   const handleChangeDate = (date: FirstDay) => {
-    setSelectedDate(date);
     const cleanMonth = date.month
       .replace(/\s*\(.*\)$/, "")
       .replace("월", "")
@@ -38,10 +46,39 @@ export default function RescheduleSheet({
       .replace("일", "")
       .padStart(2, "0");
 
+    const formattedDate = `${date.year}-${cleanMonth}-${cleanDay}`;
+    const formattedTime = to24HourTime(date.period, date.time);
+
+    const isUnavailable = allSessions?.schedules
+      ? Object.values(allSessions.schedules).some((region) => {
+          return region.content.some((schedule) => {
+            // 현재 수정 중인 세션 제외
+            if (schedule.classSessionId === sessionId) {
+              return false;
+            }
+
+            // 날짜 & 시간 똑같은지 비교
+            const isSameDate = schedule.classDate === formattedDate;
+            const isSameTime =
+              schedule.classStart.trim() === formattedTime.trim();
+
+            return isSameDate && isSameTime;
+          });
+        })
+      : false;
+
+    // 유효한 날짜가 아닐 때
+    if (isUnavailable) {
+      close();
+      toast.warning("이미 있는 일정이에요");
+      return;
+    }
+
+    setSelectedDate(date);
     mutate({
       sessionId,
-      sessionDate: `${date.year}-${cleanMonth}-${cleanDay}`,
-      start: to24HourTime(date.period, date.time),
+      sessionDate: formattedDate,
+      start: formattedTime,
     });
 
     close();
@@ -58,7 +95,7 @@ export default function RescheduleSheet({
     }
 
     const paddedHour = String(hour).padStart(2, "0");
-    return `${paddedHour}:${minuteStr}`;
+    return `${paddedHour}:${minuteStr}:00`;
   }
 
   function convertToFirstDay(date: Date, rawTime: string): FirstDay {


### PR DESCRIPTION
## 🐈 PR 요약
> PR 내용 한 줄로 요약
- 관련 테크스펙 링크 : x
- UT 변경사항 수정

## ✨ PR 상세
> PR 상세 내용 개조식으로 작성
- 선생님이 이미 있는 세션으로 날짜 변경을 하려고 할 때, 바텀시트 닫히고 '이미 있는 일정이에요' error 토스트 출현
- '날짜'와 '시작 시간'이 같을 때 막는 걸로 처리함
- teacher layout 최대 너비 420px로 조정

## 🚨 참고사항
> 리뷰어들이 알아야 하거나 알면 좋은 참고사항 작성

## 📸 스크린샷
> 화면 캡쳐 이미지


https://github.com/user-attachments/assets/97472925-d13d-423c-986a-7651a0d9f93e



## ✅ 체크리스트
- [x] Reviewers 태그했나요?
- [x] Label 지정했나요?
- [ ] 관련 테크스펙 링크 연결했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **버그 수정**
  - 일정 변경 시 기존 세션과 시간 중복이 있을 경우, 시트를 닫고 "이미 있는 일정이에요"라는 경고 메시지를 표시하도록 개선되었습니다.
- **스타일**
  - 선생님 레이아웃의 최대 너비가 375픽셀에서 420픽셀로 확대되어 더 넓은 화면을 제공합니다.
  - 세션 완료 및 일정 예약 버튼의 너비가 335픽셀에서 375픽셀로 조정되어 사용성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->