### PR TITLE
Fix/qa review-수업리스트갱신, 스크롤바제거, 정규일정변경ui오류 수정

### DIFF
--- a/app/(route)/(teacher)/teacher/session-change/page.tsx
+++ b/app/(route)/(teacher)/teacher/session-change/page.tsx
@@ -61,12 +61,11 @@ export default function SessionChangePage() {
         <div className="flex flex-col items-center">
           <HeaderWithBack
             title={classId || "과외 일정"}
-            mainClassName="pt-8"
+            mainClassName="pt-8 overflow-auto"
             hasBack
             onBack={onClickBack}
           >
             <SessionSchedule
-              className="mb-24"
               title={`학부모와 협의 후\n일정을 업데이트해 주세요`}
               token={classId ? undefined : (token ?? undefined)}
               classMatchingId={target?.classMatchingId}

--- a/app/(route)/globals.css
+++ b/app/(route)/globals.css
@@ -12,3 +12,7 @@ body {
   font-family: var(--font-pretendard);
   color: var(--text-color);
 }
+
+*::-webkit-scrollbar {
+  display: none;
+}

--- a/app/components/teacher/Session/SessionSchedule.tsx
+++ b/app/components/teacher/Session/SessionSchedule.tsx
@@ -100,7 +100,7 @@ export default function SessionSchedule(props: SessionScheduleProps) {
   }
 
   return (
-    <div className={cn("flex flex-col gap-[40px] px-5 pb-[24px]", className)}>
+    <div className={cn("mb-[100px] flex flex-col gap-[40px] px-5", className)}>
       <TitleSection>
         <TitleSection.Title className="whitespace-pre">
           {title}

--- a/app/components/teacher/SessionList/index.tsx
+++ b/app/components/teacher/SessionList/index.tsx
@@ -45,11 +45,13 @@ export default function SessionList({ classId }: SessionListProps) {
     if (!data) return;
     const newContent = data.schedules[classId]?.content ?? [];
     setSessions((prev) => {
-      return page === 0 ? newContent : [...prev, ...newContent];
+      if (page === 0) return [...newContent];
+      return [...prev, ...newContent];
     });
   }, [data, classId, page]);
 
   const items: SessionItem[] = useSessionList(sessions);
+
   const params = new URLSearchParams(searchParams.toString());
 
   const changeFilter = (next: boolean) => {


### PR DESCRIPTION
## 🐈 PR 요약
> QA 반영
- 관련 테크스펙 링크 : 

## ✨ PR 상세
> sessionList 데이터가 refetch후에도 업데이트되지 않는 문제

`useSessionList`훅은 `useMemo` 를 사용하여 `sessions` 배열에 의존하고 있습니다.
기존 로직에서 동일참조의 배열을 훅에 전달하면서 리렌더링이 유발되지 않는 문제였습니다.

> 스크롤바 ui 숨김

못생긴 스크롤바 ui 제거했습니다.

> 정규 일정 변경시 고정된 버튼에 내용이 가려짐

요일을 많이 체크하면 내용이 가려지는 오류를 수정하였습니다.

## 🚨 참고사항
> x

## 📸 스크린샷
> x

## ✅ 체크리스트
- [ ] Reviewers 태그했나요?
- [ ] Label 지정했나요?
- [ ] 관련 테크스펙 링크 연결했나요?
