### PR TITLE
Fix/byunghoon ut : QA 오류 수정

### DIFF
--- a/app/(route)/(teacher)/teacher/session-complete/page.tsx
+++ b/app/(route)/(teacher)/teacher/session-complete/page.tsx
@@ -32,9 +32,6 @@ export default function SessionCompletePage() {
   const { data: sessionByToken } = useGetSessionByToken({ token: token ?? "" });
 
   const target = data?.find((item) => item.send);
-  const isEmpty =
-    !target ||
-    Object.values(target.schedules).every((arr) => (arr ?? []).length === 0);
 
   // sessionId가 있을 경우 sessions에서 데이터 추출
   const sessionFromCache = classSessionId
@@ -63,6 +60,8 @@ export default function SessionCompletePage() {
 
     return null;
   }, [sessionFromCache, sessionByToken]);
+
+  const isEmpty = !activeSessionData;
 
   const titleDate = activeSessionData?.sessionDate
     ? formatDateShort(activeSessionData.sessionDate)

--- a/app/components/teacher/SessionList/useSessionList.ts
+++ b/app/components/teacher/SessionList/useSessionList.ts
@@ -48,6 +48,7 @@ export function useSessionList(data: SessionResponse[]): SessionItem[] {
       classDay.setHours(0, 0, 0, 0);
       const isToday = classDay.getTime() === today.getTime();
       const isTodayOrPast = classDay.getTime() <= today.getTime();
+      const isFuture = classDay.getTime() > today.getTime();
       const showMoneyReminder = isTodayOrPast && !complete && !cancel;
 
       let statusLabel = "";
@@ -64,6 +65,9 @@ export function useSessionList(data: SessionResponse[]): SessionItem[] {
         case isToday:
           statusLabel = "오늘";
           actions = [BTN_CANCEL, BTN_RESCHEDULE, BTN_COMPLETE];
+          break;
+        case isFuture:
+          actions = [BTN_CANCEL, BTN_RESCHEDULE];
           break;
         default:
           actions = [BTN_CANCEL, BTN_RESCHEDULE, BTN_COMPLETE];


### PR DESCRIPTION
## 🐈 PR 요약
> PR 내용 한 줄로 요약
- 관련 테크스펙 링크 : 

## ✨ PR 상세
> PR 상세 내용 개조식으로 작성

- 미래 시점 카드에서 과외완료 버튼 렌더링되지 않도록 변경
- 과외완료 페이지 isEmpty 기준을 send가 아닌 일정이 null인 경우로 변경.

## 🚨 참고사항
> 리뷰어들이 알아야 하거나 알면 좋은 참고사항 작성

## 📸 스크린샷
> 화면 캡쳐 이미지

## ✅ 체크리스트
- [x] Reviewers 태그했나요?
- [x] Label 지정했나요?
- [ ] 관련 테크스펙 링크 연결했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 세션이 비어있는지 판단하는 기준이 단순화되어, 세션 데이터가 없을 때만 비어있음으로 간주됩니다.

- **신규 기능**
  - 앞으로 예정된 세션에 대해 '취소'와 '일정 변경' 버튼만 표시되며, '완료' 버튼은 더 이상 제공되지 않습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->