### PR TITLE
fix: 완료 이후 미완료 리페칭 문제 수정

### DIFF
--- a/app/hooks/mutation/usePatchSessions.ts
+++ b/app/hooks/mutation/usePatchSessions.ts
@@ -98,6 +98,9 @@ export function useSessionMutations() {
       if (classId) {
         params.set("classId", classId);
       }
+
+      queryClient.invalidateQueries({ queryKey: ["sessions"] });
+
       params.set("is-complete", "true");
       router.push(`/teacher/session-schedule?${params.toString()}`);
 


### PR DESCRIPTION
## 🐈 PR 요약
> PR 내용 한 줄로 요약
- 관련 테크스펙 링크 : x
- 미완료 리페칭 문제 수정

## ✨ PR 상세
> PR 상세 내용 개조식으로 작성
- 과외 완료 이후, 미완료 탭 데이터들이 리페칭이 안 되는 문제 수정했습니다!

## 🚨 참고사항
> 리뷰어들이 알아야 하거나 알면 좋은 참고사항 작성
- `meta`의 `invalidates`로 `"sessions"` 추가하면 리페칭 타이밍이 꼬여서, 과외 완료하면 완료탭으로 돌아와야 하는데 미완료탭으로 돌아가더라구요? (리페칭 하면서 `inComplete`가 `false`인 걸 불러와서 그런듯?)
- 그래서 `queryClient.invalidateQueries({ queryKey: ["sessions"] });`를 추가했는데 그럼 완료탭으로 잘 리다이렉트는 되는데, 미완료탭으로 이동하면 깜빡임 이후 데이터가 다시 불러와져요
- 그래서 뭐가 더 나은지............ 모르겠다는... 뭘로 할까요

## 📸 스크린샷
> 화면 캡쳐 이미지

## ✅ 체크리스트
- [x] Reviewers 태그했나요?
- [x] Label 지정했나요?
- [ ] 관련 테크스펙 링크 연결했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 세션 관련 작업 후 세션 목록이 자동으로 최신 상태로 갱신되도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->