### PR TITLE
fix: 날짜변경 시트에서 시간 같은지 비교하는 코드 제거

### DIFF
--- a/app/components/teacher/SessionList/RescheduleSheet.tsx
+++ b/app/components/teacher/SessionList/RescheduleSheet.tsx
@@ -89,12 +89,9 @@ export default function RescheduleSheet({
               return false;
             }
 
-            // 날짜 & 시간 똑같은지 비교
+            // 날짜 똑같은지 비교
             const isSameDate = schedule.classDate === formattedDate;
-            const isSameTime =
-              schedule.classStart.trim() === formattedTime.trim();
-
-            return isSameDate && isSameTime;
+            return isSameDate;
           });
         })
       : false;


### PR DESCRIPTION
## 🐈 PR 요약
> PR 내용 한 줄로 요약
- 관련 테크스펙 링크 : 

## ✨ PR 상세
> PR 상세 내용 개조식으로 작성

- 날짜변경 시트(rescheduleSheet)에 동일 시간인지 비교하는 isSameTime 코드 제거

## 🚨 참고사항
> 리뷰어들이 알아야 하거나 알면 좋은 참고사항 작성

- 날짜/시간 모두 동일한지를 비교하다보니 같은 날짜에 시간을 다르게하면 변경이 가능하더라구요. 
한 과외건에서 같은날짜 다른시간으로 할 이유가 없으므로 이 코드는 제거해서 아예 날짜만 같으면 변경하지 못하도록 했습니다.

## 📸 스크린샷
> 화면 캡쳐 이미지

## ✅ 체크리스트
- [x] Reviewers 태그했나요?
- [x] Label 지정했나요?
- [ ] 관련 테크스펙 링크 연결했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 일정 변경 시, 시간과 관계없이 날짜가 겹치는 경우만 중복 일정으로 간주하도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->