### PR TITLE
fix: 학부모 가능시간 텍스트 형태로 수정

### DIFF
--- a/app/actions/get-tutoring/index.ts
+++ b/app/actions/get-tutoring/index.ts
@@ -24,7 +24,7 @@ const tutoringResponse = z.object({
   dong: z.string(),
   goals: z.array(z.string()),
   favoriteStyle: z.string().nullable(),
-  parentDayTimes: z.array(dayTimeSchema),
+  wantedTime: z.string(),
   teacherDayTimes: z.array(dayTimeSchema),
   matchStatus: z.enum([
     MATCHING_STATUS.REJECT,

--- a/app/components/teacher/MatchingInfo.tsx
+++ b/app/components/teacher/MatchingInfo.tsx
@@ -1,7 +1,7 @@
 import { TutoringResponse } from "app/actions/get-tutoring";
 
 export function MatchingInfo(
-  props: Omit<TutoringResponse, "parentDayTimes" | "teacherDayTimes">,
+  props: Omit<TutoringResponse, "wantedTime" | "teacherDayTimes">,
 ) {
   const activeLocation =
     props.online === "비대면"

--- a/app/components/teacher/MatchingProposal.tsx
+++ b/app/components/teacher/MatchingProposal.tsx
@@ -3,8 +3,6 @@
 import { ReactNode, useState } from "react";
 import { useRouter } from "next/navigation";
 
-import formatDayTimes from "@/utils/formatDayTimes";
-import BulletList from "@/ui/List/BulletList";
 import { MATCHING_STATUS, type MatchingStatus } from "@/constants/matching";
 
 import { MatchingModal } from "./MatchingModal";
@@ -118,7 +116,7 @@ export function MatchingProposal({ token }: { token: string }) {
           </div>
         }
       >
-        <BulletList items={formatDayTimes(data.parentDayTimes)} />
+        <p>{data.wantedTime}</p>
       </ProfileInfoBox>
       {finalStatus === "대기" && (
         <>


### PR DESCRIPTION
## 🐈 PR 요약
> PR 내용 한 줄로 요약
- 관련 테크스펙 링크 : x
- 학부모 가능시간 텍스트 형태로 수정

## ✨ PR 상세
> PR 상세 내용 개조식으로 작성
- 기존 요일/시간 배열로 받던 학부모 가능 시간을 텍스트로 받도록 수정했습니다~

## 🚨 참고사항
> 리뷰어들이 알아야 하거나 알면 좋은 참고사항 작성

## 📸 스크린샷
> 화면 캡쳐 이미지
<img width="370" alt="image" src="https://github.com/user-attachments/assets/1caaf0ad-7c25-4e11-aab3-b99e9ee530ab" />


## ✅ 체크리스트
- [x] Reviewers 태그했나요?
- [x] Label 지정했나요?
- [ ] 관련 테크스펙 링크 연결했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 부모가 원하는 시간을 단일 문자열로 표시하도록 변경되었습니다.

- **버그 수정**
    - 부모의 희망 시간 표시 방식이 리스트에서 텍스트로 간소화되어 정보 확인이 더 쉬워졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->