### PR TITLE
fix: 과외건 공지 페이지 스타일 수정

### DIFF
--- a/app/components/teacher/MatchingProposal.tsx
+++ b/app/components/teacher/MatchingProposal.tsx
@@ -89,7 +89,7 @@ export function MatchingProposal({ token }: { token: string }) {
           ))}
         </div>
       </ProfileInfoBox>
-      <div className="order-2 h-[10px] w-[375px] flex-none self-stretch bg-[#F5F5F5]" />
+      <div className="order-2 h-[10px] flex-none self-stretch bg-[#F5F5F5]" />
       <ProfileInfoBox
         title={
           <p>
@@ -101,30 +101,32 @@ export function MatchingProposal({ token }: { token: string }) {
       >
         {data.favoriteStyle}
       </ProfileInfoBox>
-      <div className="order-2 h-[10px] w-[375px] flex-none self-stretch bg-[#F5F5F5]" />
       {data.wantedTime && (
-        <ProfileInfoBox
-          title={
-            <div className="flex flex-col gap-1">
-              <p>
-                학부모님이
-                <span className="text-primaryNormal"> 선호하는 시간</span>
-                이에요.
-              </p>
-              <p className="text-[15px] font-medium leading-[152%] text-labelAssistive">
-                학부모님과 협의하여 시간을 조율할 수 있어요.
-              </p>
-            </div>
-          }
-        >
-          <p>{data.wantedTime}</p>
-        </ProfileInfoBox>
+        <>
+          <div className="order-2 h-[10px] flex-none self-stretch bg-[#F5F5F5]" />
+          <ProfileInfoBox
+            title={
+              <div className="flex flex-col gap-1">
+                <p>
+                  학부모님이
+                  <span className="text-primaryNormal"> 선호하는 시간</span>
+                  이에요.
+                </p>
+                <p className="text-[15px] font-medium leading-[152%] text-labelAssistive">
+                  학부모님과 협의하여 시간을 조율할 수 있어요.
+                </p>
+              </div>
+            }
+          >
+            <p>{data.wantedTime}</p>
+          </ProfileInfoBox>
+        </>
       )}
       {finalStatus === "대기" && (
         <>
           <div className="flex justify-center gap-[15px] align-middle">
             <button
-              className="order-0 flex h-[58px] w-[160px] flex-none flex-row items-center justify-center gap-[6px] self-stretch rounded-[8px] bg-primaryTint p-[16px] font-bold text-primaryNormal"
+              className="order-0 ml-5 h-[58px] w-full min-w-[135px] rounded-[8px] bg-primaryTint p-[16px] font-bold text-primaryNormal"
               onClick={() => {
                 setMatchingStatus("REJECT");
                 openModal();
@@ -133,7 +135,7 @@ export function MatchingProposal({ token }: { token: string }) {
               이번건 넘길게요
             </button>
             <button
-              className="order-0 flex h-[58px] w-[160px] flex-none flex-row items-center justify-center gap-[6px] self-stretch rounded-[8px] bg-primaryNormal p-[16px] px-[36px] font-bold text-white"
+              className="order-0 mr-5 h-[58px] w-full min-w-[135px] rounded-[8px] bg-primaryNormal p-[16px] font-bold text-white"
               onClick={() => {
                 router.push(`/teacher/notify/${token}/select-time`);
               }}


### PR DESCRIPTION
## 🐈 PR 요약
> PR 내용 한 줄로 요약
- 관련 테크스펙 링크 : -

## ✨ PR 상세
> PR 상세 내용 개조식으로 작성

- 과외건 공지 페이지 구분선 고정 width 삭제
- 구분선 조건부 렌더링 안으로 이동
- 버튼 불필요해보이는 스타일 삭제 및 넓이에 맞게 조절되도록 스타일조정.

## 🚨 참고사항
> 리뷰어들이 알아야 하거나 알면 좋은 참고사항 작성

- 기준 넓이가 420px로 늘어나면서 기존에 고정되어있던 값으로 인해 스타일이 깨져보이는 경우가 생겨서 스타일 수정했습니다!
- wantedTime에 데이터 없을 경우, 아예 렌더링하지 않는게 더 깔끔할 것 같아서 구분선만 안으로 넣었습니다.

## 📸 스크린샷
> 화면 캡쳐 이미지

![FireShot Capture 124 - Y-edu - localhost](https://github.com/user-attachments/assets/8327c417-51c4-488d-b6e0-6498a1cde59a)
![FireShot Capture 125 - Y-edu - localhost](https://github.com/user-attachments/assets/dbbbcf8d-d330-4589-b0ab-edadd862ecd5)


## ✅ 체크리스트
- [x] Reviewers 태그했나요?
- [x] Label 지정했나요?
- [] 관련 테크스펙 링크 연결했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - 제안 수락/거절 버튼과 구분선의 고정 너비가 제거되어, 화면 크기에 따라 더 유연하게 표시됩니다.
  - 버튼과 레이아웃의 여백 및 정렬이 개선되어 가독성과 사용성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->