### PR TITLE
Fix/redirect to session tab : 알림톡에서 해당 과외건 탭으로 바로 이동하도록 프론트 코드 수정, 어드민 관련 수정

### DIFF
--- a/app/(route)/(teacher)/teacher/session-complete/page.tsx
+++ b/app/(route)/(teacher)/teacher/session-complete/page.tsx
@@ -36,7 +36,7 @@ export default function SessionCompletePage() {
   // sessionId가 있을 경우 sessions에서 데이터 추출
   const sessionFromCache = classSessionId
     ? (Object.values(sessions?.schedules ?? {})
-        .flatMap((schedulePage) => schedulePage.content)
+        .flatMap((schedulePage) => schedulePage.schedules.content)
         .find((session) => session.classSessionId === Number(classSessionId)) ??
       null)
     : null;

--- a/app/(route)/(teacher)/teacher/session-review/page.tsx
+++ b/app/(route)/(teacher)/teacher/session-review/page.tsx
@@ -25,7 +25,7 @@ export default function SessionReviewPage() {
   const targetSession = useMemo(() => {
     if (!data) return undefined;
     return Object.values(data.schedules)
-      .flatMap((schedulePage) => schedulePage.content)
+      .flatMap((schedulePage) => schedulePage.schedules.content)
       .find((s) => s.classSessionId === sessionId);
   }, [data, sessionId]);
 

--- a/app/(route)/(teacher)/teacher/session-schedule/page.tsx
+++ b/app/(route)/(teacher)/teacher/session-schedule/page.tsx
@@ -18,8 +18,12 @@ export default function TeacherSessionScheduleListPage() {
   if (isLoading) {
     return <LoadingUI />;
   }
+  const schedules = data?.schedules ?? {};
+  const classIds = Object.keys(schedules);
+  const defaultClassId =
+    classIds.find((id) => schedules[id].send === true) ?? classIds[0];
 
-  const tabs = Object.keys(data!.schedules).map((classId) => ({
+  const tabs = classIds.map((classId) => ({
     trigger: classId,
     content: <SessionList key={classId} classId={classId} />,
   }));
@@ -30,6 +34,7 @@ export default function TeacherSessionScheduleListPage() {
         <TabBar
           tabs={tabs}
           paramKey="classId"
+          initialTab={defaultClassId}
           listClassName="overflow-x-auto whitespace-nowrap scrollbar-hide"
           buttonClassName="flex-initial px-[10px] scroll-ml-5"
         />

--- a/app/actions/post-getSessions/index.ts
+++ b/app/actions/post-getSessions/index.ts
@@ -41,8 +41,13 @@ export interface SchedulePageInfo {
   empty: boolean;
 }
 
+export interface ScheduleWithSend {
+  schedules: SchedulePageInfo;
+  send: boolean;
+}
+
 export interface SessionsResponse {
-  schedules: Record<string, SchedulePageInfo>;
+  schedules: Record<string, ScheduleWithSend>;
 }
 
 export const getSessions = async (

--- a/app/components/admin/ClassList.tsx
+++ b/app/components/admin/ClassList.tsx
@@ -43,7 +43,7 @@ function ClassList({
     getPaginationRowModel: getPaginationRowModel(),
     initialState: {
       pagination: {
-        pageSize: 15,
+        pageSize: 100,
       },
     },
   });

--- a/app/components/teacher/SessionList/index.tsx
+++ b/app/components/teacher/SessionList/index.tsx
@@ -41,7 +41,7 @@ export default function SessionList({ classId }: SessionListProps) {
 
   useEffect(() => {
     if (!data) return;
-    const newContent = data.schedules[classId]?.content ?? [];
+    const newContent = data.schedules[classId]?.schedules?.content ?? [];
     setSessions(newContent);
   }, [data, classId]);
 

--- a/app/hooks/mutation/usePatchSessions.ts
+++ b/app/hooks/mutation/usePatchSessions.ts
@@ -99,7 +99,8 @@ export function useSessionMutations() {
         params.set("classId", classId);
       }
 
-      queryClient.invalidateQueries({ queryKey: ["sessions"] });
+      await queryClient.invalidateQueries({ queryKey: ["sessions"] });
+      await queryClient.refetchQueries({ queryKey: ["sessions"] });
 
       params.set("is-complete", "true");
       router.push(`/teacher/session-schedule?${params.toString()}`);

--- a/app/ui/Bar/TabBar.tsx
+++ b/app/ui/Bar/TabBar.tsx
@@ -15,6 +15,7 @@ interface TabBarProps {
   paramKey?: string;
   listClassName?: string;
   buttonClassName?: string;
+  initialTab?: string;
 }
 
 export default function TabBar({
@@ -23,12 +24,14 @@ export default function TabBar({
   paramKey,
   listClassName = "",
   buttonClassName = "",
+  initialTab = "",
 }: TabBarProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const initial = paramKey
-    ? (searchParams.get(paramKey) ?? tabs[0].trigger)
-    : tabs[0].trigger;
+  const initial =
+    paramKey && searchParams.get(paramKey)
+      ? searchParams.get(paramKey)!
+      : (initialTab ?? tabs[0].trigger);
   const [selectedTab, setSelectedTab] = useState(initial);
   const sectionRefs = useRef<Record<string, HTMLDivElement | null>>({}).current;
   const buttonRefs = useRef<Array<HTMLButtonElement | null>>([]);


### PR DESCRIPTION
## 🐈 PR 요약
> PR 내용 한 줄로 요약
- 관련 테크스펙 링크 : -

## ✨ PR 상세
> PR 상세 내용 개조식으로 작성

- 알림톡 '날짜변경' 링크에서 해당 과외건의 탭으로 바로 리다이렉트 되도록 코드 수정
- 과외완료 후 해당 완료된 과외건 리뷰확인 버튼을 클릭했을 때 데이터가 fetch 되지 않아 에러페이지로 이동하는 오류 해결
- 어드민 '수업관리' 탭 항목 100건씩 보여주도록 수정.

## 🚨 참고사항
> 리뷰어들이 알아야 하거나 알면 좋은 참고사항 작성

- 이제 해당 과외건 탭으로 바로 이동합니다!
- ut좀 해보다가 과외완료 후 해당 과외건 보기를 바로 했을때 에러페이지로 뜨는 오류를 발견해서 수정했습니다.
- 영대님 요청으로 어드민 수업관리 항목 100건씩 보여주도록 수정했는데 '과외상태'에 따른 필터링 기능 있으면 좋겠다고 생각해서 코드는 다 짜놨습니다. 근데 너무 지저분해서 시간날때 정리해서 다시 PR 올릴게용

## 📸 스크린샷
> 화면 캡쳐 이미지

## ✅ 체크리스트
- [x] Reviewers 태그했나요?
- [x] Label 지정했나요?
- [ ] 관련 테크스펙 링크 연결했나요?
