### PR TITLE
fix: 어드민 매칭관리 탭 column 수정

### DIFF
--- a/app/ui/Columns/ParentsColumns.tsx
+++ b/app/ui/Columns/ParentsColumns.tsx
@@ -11,6 +11,10 @@ export function getParentColumns(
   onToggleStatus: (applicationFormId: string) => void,
 ) {
   return [
+    columnHelper.accessor("applicationFormId", {
+      header: "수업코드",
+      cell: (props) => props.getValue() || "-",
+    }),
     columnHelper.accessor("kakaoName", {
       header: "카톡 이름",
       cell: (props) => props.getValue() || "-",
@@ -19,6 +23,10 @@ export function getParentColumns(
       id: "classStatus",
       header: "수업 시수",
       cell: (props) => props.getValue(),
+    }),
+    columnHelper.accessor("pay", {
+      header: "월 수업료",
+      cell: (info) => formatMonthlyFee(info.getValue()),
     }),
     columnHelper.accessor("scheduledClasses", {
       header: "확정 수업 정보",
@@ -39,19 +47,23 @@ export function getParentColumns(
         );
       },
     }),
-    columnHelper.accessor("pay", {
-      header: "월 수업료",
-      cell: (info) => formatMonthlyFee(info.getValue()),
-    }),
     columnHelper.accessor("wantedSubject", {
-      header: "원하는 과목",
-    }),
-    columnHelper.accessor("source", {
-      header: "유입경로",
+      header: "과목",
     }),
     columnHelper.accessor("createdAt", {
       header: "신청일",
-      cell: (props) => new Date(props.getValue()).toLocaleString(),
+      cell: (props) => {
+        const date = new Date(props.getValue());
+        return date.toLocaleString("ko-KR", {
+          year: undefined,
+          month: "numeric",
+          day: "numeric",
+          hour: "numeric",
+          minute: "numeric",
+          second: undefined,
+          hour12: true,
+        });
+      },
     }),
     // 수락 상태: accept/total
     columnHelper.accessor((row) => `${row.accept}/${row.total}`, {


### PR DESCRIPTION
## 🐈 PR 요약
> PR 내용 한 줄로 요약
- 관련 테크스펙 링크 : x
- 어드민 매칭관리 탭 column 순서 등등 수정

## ✨ PR 상세
> PR 상세 내용 개조식으로 작성
- 어드민 매칭관리 탭 순서 영대님이 요청하신대로 수정
- 테이블 칼럼에 '수업코드' 추가
- 신청일 날짜 포맷 수정(연도, 초 안 보이게)

## 🚨 참고사항
> 리뷰어들이 알아야 하거나 알면 좋은 참고사항 작성

## 📸 스크린샷
> 화면 캡쳐 이미지
<img width="1272" alt="image" src="https://github.com/user-attachments/assets/9a7ee917-ad05-419c-ba6a-3880a53643f5" />


## ✅ 체크리스트
- [x] Reviewers 태그했나요?
- [x] Label 지정했나요?
- [ ] 관련 테크스펙 링크 연결했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * "수업코드" 컬럼이 표의 맨 앞에 추가되어 신청서 ID를 표시합니다.

* **개선 사항**
  * "월 수업료" 컬럼의 순서가 앞당겨졌습니다.
  * "원하는 과목" 컬럼명이 "과목"으로 변경되었습니다.
  * "source" 컬럼이 표에서 제거되었습니다.
  * "createdAt" 날짜 컬럼이 한국어 형식(월, 일, 시, 분, 12시간제)으로 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->