### PR TITLE
fix: 카드 인덱스 3부터 과외완료 안되는 문제 수정

### DIFF
--- a/app/(route)/(teacher)/teacher/session-complete/page.tsx
+++ b/app/(route)/(teacher)/teacher/session-complete/page.tsx
@@ -27,7 +27,7 @@ export default function SessionCompletePage() {
   const token = searchParams.get("token") ?? "";
   const classSessionId = searchParams.get("sessionId");
 
-  const { data: sessions } = useGetSessions(token, 0, 3);
+  const { data: sessions } = useGetSessions(token, 0, 30);
   const { data, isLoading } = useGetSchedules({ token });
   const { data: sessionByToken } = useGetSessionByToken({ token: token ?? "" });
 


### PR DESCRIPTION
## 🐈 PR 요약
> PR 내용 한 줄로 요약
- 관련 테크스펙 링크 : x
- 카드 인덱스 3 이후부터 과외완료 안 되는 문제 수정

## ✨ PR 상세
> PR 상세 내용 개조식으로 작성
- `session-schedule`에서는 3개 이후의 카드들도 불러올 수 있는데, `session-complete`에서는 3개까지만 고정적으로 받아와서 그 이후로는 session 카드가 없다고 인지되어 `isEmpty` 로직이 동작한 것 같네요!
- 의논해주신 것처럼 3개가 아닌 안전하게 30개를 받아오도록 수정했습니다

## 🚨 참고사항
> 리뷰어들이 알아야 하거나 알면 좋은 참고사항 작성

저도 뭔가 근본적인 해결방법은 아니라고 생각해서 생각해 본 방법은 다음과 같아요!
- '더보기' 눌렀을 때 카드 불러오는 로직은 `SessionList`에 있음
- `SessionList`에서는 `useGetSessions`로 수업 불러올 때는 50개씩 불러오고, `isCompelte`, `classId`를 지정해준 채로 캐싱 -> 그래서 `session-complete`의 `useGetSessions`와 파라미터가 다르기 때문에 `session-complete`의 `useGetSessions`는 `SessionList`에서 캐싱된 데이터를 못 쓰는 거
- 그래서 파라미터를 맞춰주고 캐싱된 데이터를 쓰기 (`isComplete`는 기본값을 쓰면 될 것 같고,`classId` 같은 것들 잘하면 지정해줄 수 있을 것 같아요)

아니면 `sessionId`랑 `classId`로 데이터 불러오는 api를 새로 짜든지...? 하면 좋을 것 같네요!
더 좋은 방법이 있다면 알려주세요!!

## 📸 스크린샷
> 화면 캡쳐 이미지

## ✅ 체크리스트
- [x] Reviewers 태그했나요?
- [x] Label 지정했나요?
- [ ] 관련 테크스펙 링크 연결했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 세션 목록에서 한 번에 표시되는 세션 수가 3개에서 30개로 증가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->