### PR TITLE
fix: 카카오 인앱브라우저에서 스크롤 모달 옵션 변경 시 메뉴바 사라짐으로 화면 움직이는 이슈 해결

### DIFF
--- a/app/ui/BottomSheet/index.tsx
+++ b/app/ui/BottomSheet/index.tsx
@@ -23,14 +23,21 @@ export default function BottomSheet({
   useClickoutside(sheetRef, onClose);
 
   useEffect(() => {
+    const scrollY = window.scrollY;
+
     if (isOpen) {
-      document.body.classList.add("overflow-hidden");
-    } else {
-      document.body.classList.remove("overflow-hidden");
+      document.body.style.position = "fixed";
+      document.body.style.top = `-${scrollY}px`;
+      document.body.style.overflowY = "hidden";
+      document.body.style.width = "100%";
     }
 
     return () => {
-      document.body.classList.remove("overflow-hidden");
+      document.body.style.position = "";
+      document.body.style.top = "";
+      document.body.style.overflowY = "";
+      document.body.style.width = "";
+      window.scrollTo(0, scrollY);
     };
   }, [isOpen]);
 


### PR DESCRIPTION
## 🐈 PR 요약
> PR 내용 한 줄로 요약
- 관련 테크스펙 링크 : -

## ✨ PR 상세
> PR 상세 내용 개조식으로 작성

- [ 카카오 인앱브라우저 환경 ]
과외 스케줄 리스트에서 '날짜변경' 시 나오는 스크롤 모달에서 옵션을 스크롤 할 때 브라우저 상/하단의 메뉴바가 사라지고 나타나는 동작으로 인해 옵션 선택이 잘 안되고 화면이 움직이는 이슈를 해결했습니다. 

## 🚨 참고사항
> 리뷰어들이 알아야 하거나 알면 좋은 참고사항 작성

- 기존에 이미 BottomSheet 컴포넌트로 스크롤 막는 코드는 적용이 되어있었더라구요! 그래서 '정규일정 변경' 페이지에서 뜨는 모달에서는 스크롤해도 화면이 움직이지 않았는데 명확한 이유는 모르겠지만 gpt가 추천해준 css를 추가했더니 전체에서 적용이 되었습니다!

## 📸 스크린샷
> 화면 캡쳐 이미지

https://github.com/user-attachments/assets/d8b003d9-f1dc-4ab8-aca5-8f9e9052e945

## ✅ 체크리스트
- [x] Reviewers 태그했나요?
- [x] Label 지정했나요?
- [ ] 관련 테크스펙 링크 연결했나요?
