### PR TITLE
feat: 스크롤피커에서 위아래 옵션 터치로 선택 가능하도록 코드 추가

### DIFF
--- a/app/ui/ScrollPicker/index.tsx
+++ b/app/ui/ScrollPicker/index.tsx
@@ -33,6 +33,15 @@ export default function ScrollPicker({
     }, 80);
   };
 
+  const scrollToIndex = (index: number) => {
+    const el = ref.current;
+    if (!el) return;
+    el.scrollTo({
+      top: index * ITEM_HEIGHT,
+      behavior: "smooth",
+    });
+  };
+
   useEffect(() => {
     const index = options.findIndex((opt) => opt === selected);
     if (ref.current) {
@@ -50,16 +59,17 @@ export default function ScrollPicker({
         className="h-full snap-y snap-mandatory overflow-y-scroll scroll-smooth scrollbar-hide"
       >
         <div className="flex flex-col items-center py-[56px]">
-          {options.map((opt) => (
-            <div
+          {options.map((opt, i) => (
+            <button
               key={opt}
+              onClick={() => scrollToIndex(i)}
               className={cn(
                 "flex h-[56px] w-full snap-center items-center justify-center whitespace-nowrap px-[12px] text-[16px] font-medium text-[#C9CBCF] transition-all",
                 selected === opt && "text-grey-900",
               )}
             >
               {opt}
-            </div>
+            </button>
           ))}
         </div>
       </div>


### PR DESCRIPTION
## 🐈 PR 요약
> PR 내용 한 줄로 요약
- 관련 테크스펙 링크 : 

## ✨ PR 상세
> PR 상세 내용 개조식으로 작성

-스크롤피커에서 위/아래 옵션을 터치했을 때에 해당 옵션으로 스크롤되며 선택되도록 코드 추가

## 🚨 참고사항
> 리뷰어들이 알아야 하거나 알면 좋은 참고사항 작성

- 기존 div로 되어있던 옵션 요소를 button으로 변경하였습니다.

## 📸 스크린샷
> 화면 캡쳐 이미지

https://github.com/user-attachments/assets/81c442d2-f564-4d75-86a6-e77eff4cc4c9

## ✅ 체크리스트
- [x] Reviewers 태그했나요?
- [x] Label 지정했나요?
- [ ] 관련 테크스펙 링크 연결했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 스크롤 목록의 항목을 클릭하면 해당 항목으로 부드럽게 스크롤되는 기능이 추가되었습니다.

* **스타일**
  * 스크롤 목록의 항목이 `<div>`에서 `<button>` 요소로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->