### PR TITLE
fix: 수업관리 탭에 정규일정 노출

### DIFF
--- a/app/actions/graphql/class-management.ts
+++ b/app/actions/graphql/class-management.ts
@@ -11,7 +11,9 @@ export const GET_CLASSLIST = gql`
     ) {
       classManagement {
         schedule {
+          classScheduleId
           day
+          start
           classMinute
         }
       }

--- a/app/hooks/query/useGetClassList.ts
+++ b/app/hooks/query/useGetClassList.ts
@@ -22,7 +22,9 @@ export interface Class {
   matchingId: number;
   classManagement: {
     schedule: {
+      classScheduleId: number;
       day: string;
+      start: string;
       classMinute: number;
     }[];
   };

--- a/app/ui/Columns/ClassColumns.tsx
+++ b/app/ui/Columns/ClassColumns.tsx
@@ -21,6 +21,35 @@ const statusColors = {
   일시중단: "bg-yellow-100 text-yellow-800",
 } as const;
 
+const dayMap: Record<string, string> = {
+  MON: "월",
+  TUE: "화",
+  WED: "수",
+  THU: "목",
+  FRI: "금",
+  SAT: "토",
+  SUN: "일",
+};
+
+function DayTimeCell({
+  scheduleList,
+}: {
+  scheduleList: Class["classManagement"]["schedule"];
+}) {
+  if (!scheduleList?.length) return "-";
+
+  return (
+    <div>
+      {scheduleList.map((item, index) => (
+        <div key={item.classScheduleId}>
+          {dayMap[item.day] || item.day} {item.start}
+          {index < scheduleList.length - 1 && ", "}
+        </div>
+      ))}
+    </div>
+  );
+}
+
 // 과외 상태 칩
 function StatusCell({
   status,
@@ -132,6 +161,15 @@ export function getClassColumns(
           </div>
         );
       },
+    }),
+    columnHelper.display({
+      id: "dayTime",
+      header: "정규일정",
+      cell: (props) => (
+        <DayTimeCell
+          scheduleList={props.row.original.classManagement.schedule}
+        />
+      ),
     }),
     columnHelper.accessor("applicationFormId", {
       header: "수업코드",

--- a/app/ui/Columns/ClassColumns.tsx
+++ b/app/ui/Columns/ClassColumns.tsx
@@ -40,10 +40,9 @@ function DayTimeCell({
 
   return (
     <div>
-      {scheduleList.map((item, index) => (
+      {scheduleList.map((item) => (
         <div key={item.classScheduleId}>
           {dayMap[item.day] || item.day} {item.start}
-          {index < scheduleList.length - 1 && ", "}
         </div>
       ))}
     </div>

--- a/app/ui/Columns/ClassColumns.tsx
+++ b/app/ui/Columns/ClassColumns.tsx
@@ -142,6 +142,10 @@ export function getClassColumns(
   onStatusChange: (rowIndex: number, newStatus: ClassStatus) => void,
 ) {
   return [
+    columnHelper.accessor("applicationFormId", {
+      header: "수업코드",
+      cell: (props) => props.getValue(),
+    }),
     columnHelper.accessor("parent.kakaoName", {
       header: "카톡 이름",
       cell: (props) => props.getValue() || "-",
@@ -170,10 +174,6 @@ export function getClassColumns(
           scheduleList={props.row.original.classManagement.schedule}
         />
       ),
-    }),
-    columnHelper.accessor("applicationFormId", {
-      header: "수업코드",
-      cell: (props) => props.getValue(),
     }),
     columnHelper.accessor("subject", {
       header: "과목",


### PR DESCRIPTION
## 🐈 PR 요약
> PR 내용 한 줄로 요약
- 관련 테크스펙 링크 : x
- `수업관리` 탭에 정규일정 노출

## ✨ PR 상세
> PR 상세 내용 개조식으로 작성
- 현재 선생님들이 하루 안에 수업리뷰 잘 참여하는지 트래킹하고 있는데, `매칭관리` 탭이 아니면 정규일정을 확인하기가 어려운 상황이었습니다.
- 하지만 `매칭관리` 탭에서는 실제로 성사된 수업과 성사되지 않은 수업이 섞여 있어서, 현재 성사되어 진행중인 수업에 대한 정규일정만 확인할 수 있는 방법이 필요하다고 생각했습니다!
- 그래서 `수업관리` 탭 테이블에 정규일정 노출되게 수정했습니다:)!!

## 🚨 참고사항
> 리뷰어들이 알아야 하거나 알면 좋은 참고사항 작성
- 테이블 리팩토링과 무관한 파일에서 진행된 거라 이거 먼저 main까지 머지되면 좋을 것 같아요! 테이블은 좀 더 코드리뷰 확인하고 좀 더 테스트 해보겠습니당

## 📸 스크린샷
> 화면 캡쳐 이미지
<img width="1278" height="636" alt="image" src="https://github.com/user-attachments/assets/0d4daf80-aaf0-4e5a-87ad-9e4b2f11adc8" />

## ✅ 체크리스트
- [x] Reviewers 태그했나요?
- [x] Label 지정했나요?
- [ ] 관련 테크스펙 링크 연결했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 클래스 목록 표에 "정규일정" 열이 추가되어 각 클래스의 요일과 시작 시간을 한눈에 확인할 수 있습니다.
  * 클래스 코드("수업코드") 열이 목록의 첫 번째 위치로 이동하여 가독성이 향상되었습니다.

* **개선 사항**
  * 각 클래스 일정에 고유 식별자와 시작 시간이 포함되어, 더 상세한 일정 정보가 제공됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->