### PR TITLE
Feat/session pause : 과외 일시중단 상태에 따른 조건부 렌더링, 회차정보 추가 구현

### DIFF
--- a/app/actions/post-getSessions/index.ts
+++ b/app/actions/post-getSessions/index.ts
@@ -10,6 +10,8 @@ export interface SessionResponse {
   classDate: string;
   classStart: string;
   classMinute: number;
+  currentRound: number;
+  maxRound: number;
 }
 
 export interface SortInfo {
@@ -48,6 +50,7 @@ export interface SessionScheduleInfo {
 
 export interface SessionsResponse {
   schedules: Record<string, SessionScheduleInfo>;
+  matchingStatuses: Record<string, string>;
 }
 
 export const getSessions = async (

--- a/app/components/teacher/SessionList/index.tsx
+++ b/app/components/teacher/SessionList/index.tsx
@@ -88,18 +88,20 @@ export default function SessionList({ classId }: SessionListProps) {
             onClick={() => changeFilter(true)}
           />
         </div>
-        <Button
-          leftIcon={
-            <Image src={Calender} width={20} height={20} alt="calender" />
-          }
-          className="text-grey-700 w-fit cursor-pointer justify-normal gap-1 bg-transparent px-3 py-[6px] text-sm"
-          onClick={() => {
-            params.set("classId", classId);
-            router.push(`/teacher/session-change?${params.toString()}`);
-          }}
-        >
-          정규 일정 변경
-        </Button>
+        {!isPaused && (
+          <Button
+            leftIcon={
+              <Image src={Calender} width={20} height={20} alt="calender" />
+            }
+            className="text-grey-700 w-fit cursor-pointer justify-normal gap-1 bg-transparent px-3 py-[6px] text-sm"
+            onClick={() => {
+              params.set("classId", classId);
+              router.push(`/teacher/session-change?${params.toString()}`);
+            }}
+          >
+            정규 일정 변경
+          </Button>
+        )}
       </section>
 
       {items.length === 0 && (!isPaused || isComplete) ? (

--- a/app/components/teacher/SessionList/index.tsx
+++ b/app/components/teacher/SessionList/index.tsx
@@ -125,9 +125,7 @@ export default function SessionList({ classId }: SessionListProps) {
 
           {!isComplete && isPaused && (
             <div className="flex justify-center p-5 text-center text-sm leading-[21px] text-grey-400">
-              {lastCurrentRound !== null
-                ? `${lastCurrentRound + 1}회차부터 수업이 일시정지됐어요.`
-                : `수업이 일시정지됐어요.`}
+              {`${lastCurrentRound}회차까지 완료 후 수업이 일시정지됐어요.`}
               <br />
               수업 재개는 Y-Edu에 문의해 주세요.
             </div>

--- a/app/components/teacher/SessionList/useSessionList.ts
+++ b/app/components/teacher/SessionList/useSessionList.ts
@@ -18,6 +18,8 @@ export interface SessionItem {
   actions: ActionButton[];
   showMoneyReminder: boolean;
   complete: boolean;
+  currentRound?: number;
+  maxRound?: number;
 }
 
 export function useSessionList(data: SessionResponse[]): SessionItem[] {
@@ -32,6 +34,8 @@ export function useSessionList(data: SessionResponse[]): SessionItem[] {
         complete,
         classDate,
         classStart,
+        currentRound,
+        maxRound,
       } = session;
 
       // Date 객체 생성 및 시간 포맷
@@ -82,6 +86,8 @@ export function useSessionList(data: SessionResponse[]): SessionItem[] {
         actions,
         showMoneyReminder,
         complete,
+        currentRound,
+        maxRound,
       };
     });
 

--- a/app/ui/Badge/index.tsx
+++ b/app/ui/Badge/index.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import cn from "@/utils/cn";
+
+interface BadgeProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+export default function Badge({ children, className }: BadgeProps) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center justify-center rounded-[20px] border border-grey-200 bg-white px-2 py-[2px] text-[12px] leading-[18px] text-grey-500",
+        className,
+      )}
+    >
+      {children}
+    </span>
+  );
+}

--- a/app/ui/Card/SessionListCard/index.tsx
+++ b/app/ui/Card/SessionListCard/index.tsx
@@ -11,6 +11,7 @@ import { useBottomSheet } from "@/components/teacher/SessionList/useBottomSheet"
 import RescheduleSheet from "@/components/teacher/SessionList/RescheduleSheet";
 import CancelSheet from "@/components/teacher/SessionList/CancelSheet";
 import RevertSheet from "@/components/teacher/SessionList/RevertSheet";
+import Badge from "@/ui/Badge";
 
 export interface ActionButton {
   label: string;
@@ -28,6 +29,8 @@ export interface SessionListCardProps {
   showMoneyReminder?: boolean;
   className?: string;
   initialOpen?: boolean;
+  currentRound?: number;
+  maxRound?: number;
 }
 
 export default function SessionListCard({
@@ -39,6 +42,8 @@ export default function SessionListCard({
   showMoneyReminder,
   className = "",
   initialOpen = false,
+  currentRound,
+  maxRound,
 }: SessionListCardProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -109,12 +114,20 @@ export default function SessionListCard({
             )} ${time}`}
           </span>
         </div>
-        <IconDown
-          className={cn({
-            hidden: !isToggle,
-            "rotate-180": isOpen,
-          })}
-        />
+        <div className="flex items-center">
+          <Badge className={cn(isToggle && "mr-2")}>
+            {maxRound ?? "-"}회 중{" "}
+            <strong className="ml-1 font-semibold">
+              {currentRound ?? "-"}회
+            </strong>
+          </Badge>
+          <IconDown
+            className={cn({
+              hidden: !isToggle,
+              "rotate-180": isOpen,
+            })}
+          />
+        </div>
       </div>
       {showMoneyReminder && (
         <p className="text-[14px] text-gray-500">


### PR DESCRIPTION
## 🐈 PR 요약
> PR 내용 한 줄로 요약
- 관련 테크스펙 링크 : -

## ✨ PR 상세
> PR 상세 내용 개조식으로 작성

- 과외 일시중단 상태일때 조건부 렌더링 구현
- 뱃지 컴포넌트 추가 및 과외 세션 카드에 회차정보 추가

## 🚨 참고사항
> 리뷰어들이 알아야 하거나 알면 좋은 참고사항 작성

- 기존에 미완료탭, 완료탭 각각 클릭할 때마다 데이터를 다르게 불러오고있었습니다. 그런데 이번에 일시중단 디자인에 '${n}회차 부터 일시중단 되었습니다.' 문구가 추가되어 이걸 완료된 과외건 의 currentRound 를 기반으로 하기 위해 미완료탭에서도 완료데이터를 불러오게 되었습니다. 

- 좀 더 나은 코드가 있을 것 같은데 과외 완료 기능 구현할때 진짜 많은 엣지 케이스들이 있었어서 최소 변경으로 하려다보니 이 방법으로 하게 되었어요 ㅠㅠ 더 나은 방법이 있을지 좀더 고민해보겠습니다!

- 회차정보 중 currentRound가 null로 들어오고있어 마지막회차 구분선은 데이터 들어온 이후 추가하겠습니다

- 그리고 이부분 백엔드 코드 변경되면서 정규일정 변경할때 오류가 생겨 이부분은 찬수님께 검토 요청드린 상태입니다!

## 📸 스크린샷
> 화면 캡쳐 이미지지

<img width="334" height="362" alt="스크린샷 2025-07-19 오전 2 43 03" src="https://github.com/user-attachments/assets/f9f91c75-ca00-4b11-b2b1-7c7c05d51837" />
<img width="330" height="468" alt="스크린샷 2025-07-19 오전 2 43 12" src="https://github.com/user-attachments/assets/3d42e82b-df7e-4b37-ad4b-6d9aa08e9ced" />


## ✅ 체크리스트
- [x] Reviewers 태그했나요?
- [x] Label 지정했나요?
- [ ] 관련 테크스펙 링크 연결했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 세션 카드에 현재 라운드와 최대 라운드 정보를 표시하는 뱃지 추가.
  * 새로운 뱃지(Badge) 컴포넌트 도입.

* **개선 사항**
  * 세션 리스트에서 일시정지 상태를 인식하여, UI 요소(정규 일정 변경 버튼, 더보기 버튼 등)와 안내 메시지를 조건적으로 표시.
  * 세션 데이터에 현재 라운드, 최대 라운드, 매칭 상태 정보가 포함되어 보다 상세한 정보 제공.

* **버그 수정**
  * 없음.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->