### PR TITLE
[feat] 당일휴강 flow 개발

### DIFF
--- a/app/actions/patch-sessions/index.ts
+++ b/app/actions/patch-sessions/index.ts
@@ -21,13 +21,16 @@ export function patchSessionChange({
 export function patchSessionCancel({
   sessionId,
   reason,
+  isTodayCancel = false,
 }: {
   sessionId: number;
   reason: string;
+  isTodayCancel?: boolean;
 }) {
-  return httpService.patch(
-    `/sessions/${sessionId}/cancel?cancelReason=${reason}`,
-  );
+  return httpService.patch(`/sessions/${sessionId}/cancel`, {
+    cancelReason: reason,
+    isTodayCancel,
+  });
 }
 
 export function patchSessionRevertCancel({ sessionId }: { sessionId: number }) {

--- a/app/actions/patch-sessions/index.ts
+++ b/app/actions/patch-sessions/index.ts
@@ -1,5 +1,8 @@
 import { httpService } from "@/utils/httpService";
 
+// 휴강 사유 union 타입
+export type CancelReason = "TEACHER" | "PARENT" | "TOGETHER";
+
 export function patchSessionChange({
   sessionId,
   sessionDate,

--- a/app/actions/patch-sessions/index.ts
+++ b/app/actions/patch-sessions/index.ts
@@ -24,7 +24,7 @@ export function patchSessionCancel({
   isTodayCancel = false,
 }: {
   sessionId: number;
-  reason: string;
+  reason: CancelReason;
   isTodayCancel?: boolean;
 }) {
   return httpService.patch(`/sessions/${sessionId}/cancel`, {

--- a/app/actions/post-getSessions/index.ts
+++ b/app/actions/post-getSessions/index.ts
@@ -1,9 +1,12 @@
+import { CancelReason } from "../patch-sessions";
+
 import { httpService } from "app/utils/httpService";
 
 export interface SessionResponse {
   classSessionId: number;
   cancel: boolean;
-  cancelReason: string | null;
+  isTodayCancel: boolean;
+  cancelReason: CancelReason | null;
   complete: boolean;
   understanding: string | null;
   homework: string | null;

--- a/app/components/teacher/SessionList/CancelSheet.tsx
+++ b/app/components/teacher/SessionList/CancelSheet.tsx
@@ -19,8 +19,8 @@ export function NotSameDayCancelSheet({
   const { mutate } = useSessionMutations().cancelMutation;
 
   const CANCEL_REASON = [
-    { value: "PARENT", label: "학부모 요청" },
-    { value: "TEACHER", label: "선생님 요청" },
+    { value: "PARENT", label: CANCEL_TEXT.SAME_DAY_CANCEL_BY_PARENTS_REQUEST },
+    { value: "TEACHER", label: CANCEL_TEXT.SAME_DAY_CANCEL_BY_TEACHER_REQUEST },
   ] as const;
 
   const handleSubmit = () => {

--- a/app/components/teacher/SessionList/CancelSheet.tsx
+++ b/app/components/teacher/SessionList/CancelSheet.tsx
@@ -14,7 +14,7 @@ export function NotSameDayCancelSheet({
   close: () => void;
 }) {
   const [confirmed, setConfirmed] = useState(false);
-  const [selected, setSelected] = useState("");
+  const [selected, setSelected] = useState<CancelReason>("TOGETHER");
 
   const { mutate } = useSessionMutations().cancelMutation;
 
@@ -72,31 +72,27 @@ export function SameDayCancelSheet({
   onRequestCancel: (reason: CancelReason) => void;
 }) {
   const [confirmed, setConfirmed] = useState(false);
-  const [selected, setSelected] = useState<CancelReason | null>(null);
+  const [selected, setSelected] = useState<CancelReason>("TOGETHER");
 
   const CANCEL_REASONS = [
     {
       value: "TOGETHER",
       label: CANCEL_TEXT.NOT_SAME_DAY_CANCEL,
       description: "",
-      isTodayCancel: false,
     },
     {
       value: "PARENT",
       label: CANCEL_TEXT.SAME_DAY_CANCEL_BY_PARENTS_LONG,
       description: CANCEL_TEXT.SAME_DAY_CANCEL_BY_PARENTS_DESC,
-      isTodayCancel: true,
     },
     {
       value: "TEACHER",
       label: CANCEL_TEXT.SAME_DAY_CANCEL_BY_TEACHER_LONG,
       description: CANCEL_TEXT.SAME_DAY_CANCEL_BY_TEACHER_DESC,
-      isTodayCancel: true,
     },
   ] as const;
 
   const handleSubmit = () => {
-    if (!selected) return;
     onRequestCancel(selected);
     close();
   };

--- a/app/components/teacher/SessionList/CancelSheet.tsx
+++ b/app/components/teacher/SessionList/CancelSheet.tsx
@@ -93,6 +93,7 @@ export function SameDayCancelSheet({
     },
   ] as const;
 
+  // TODO: 완료하기 누르면 당일휴강은 취소할 수 없다는 alert 모달
   const handleSubmit = () => {
     mutate({ sessionId, reason: selected });
     close();
@@ -116,16 +117,19 @@ export function SameDayCancelSheet({
           </h2>
           <div className="mb-[40px] flex flex-col gap-[32px]">
             {CANCEL_REASONS.map(({ value, label, description }) => (
-              <div key={value}>
-                <Radio
-                  label={label}
-                  selected={selected === value}
-                  onClick={() => setSelected(value)}
-                />
-                {description && (
-                  <p className="text-sm text-primary">{description}</p>
-                )}
-              </div>
+              <Radio
+                key={value}
+                label={
+                  <div className="flex flex-col">
+                    <div className="flex-start flex text-gray-700">{label}</div>
+                    {description && (
+                      <div className="text-sm text-primary">{description}</div>
+                    )}
+                  </div>
+                }
+                selected={selected === value}
+                onClick={() => setSelected(value)}
+              />
             ))}
           </div>
 

--- a/app/components/teacher/SessionList/CancelSheet.tsx
+++ b/app/components/teacher/SessionList/CancelSheet.tsx
@@ -3,8 +3,9 @@ import { useState } from "react";
 import Button from "@/ui/Button";
 import Radio from "@/ui/Radio";
 import { useSessionMutations } from "@/hooks/mutation/usePatchSessions";
+import { CANCEL_TEXT } from "@/constants/session/cancel";
 
-export default function NotSameDayCancelSheet({
+export function NotSameDayCancelSheet({
   sessionId,
   close,
 }: {
@@ -74,10 +75,23 @@ export function SameDayCancelSheet({
 
   const { mutate } = useSessionMutations().cancelMutation;
 
-  const REASONS = {
-    TEACHER: "선생님 요청",
-    PARENT: "학부모 요청",
-  } as const;
+  const CANCEL_REASONS = [
+    {
+      value: "TOGETHER",
+      label: CANCEL_TEXT.NOT_SAME_DAY_CANCEL,
+      description: "",
+    },
+    {
+      value: "PARENT",
+      label: CANCEL_TEXT.SAME_DAY_CANCEL_BY_PARENTS_LONG,
+      description: CANCEL_TEXT.SAME_DAY_CANCEL_BY_PARENTS_DESC,
+    },
+    {
+      value: "TEACHER",
+      label: CANCEL_TEXT.SAME_DAY_CANCEL_BY_TEACHER_LONG,
+      description: CANCEL_TEXT.SAME_DAY_CANCEL_BY_TEACHER_DESC,
+    },
+  ] as const;
 
   const handleSubmit = () => {
     mutate({ sessionId, reason: selected });
@@ -101,13 +115,17 @@ export function SameDayCancelSheet({
             휴강 사유를 선택해주세요.
           </h2>
           <div className="mb-[40px] flex flex-col gap-[32px]">
-            {Object.values(REASONS).map((reason) => (
-              <Radio
-                key={reason}
-                label={reason}
-                selected={selected === reason}
-                onClick={() => setSelected(reason)}
-              />
+            {CANCEL_REASONS.map(({ value, label, description }) => (
+              <div key={value}>
+                <Radio
+                  label={label}
+                  selected={selected === value}
+                  onClick={() => setSelected(value)}
+                />
+                {description && (
+                  <p className="text-sm text-primary">{description}</p>
+                )}
+              </div>
             ))}
           </div>
 

--- a/app/components/teacher/SessionList/CancelSheet.tsx
+++ b/app/components/teacher/SessionList/CancelSheet.tsx
@@ -4,7 +4,7 @@ import Button from "@/ui/Button";
 import Radio from "@/ui/Radio";
 import { useSessionMutations } from "@/hooks/mutation/usePatchSessions";
 
-export default function CancelSheet({
+export default function NotSameDayCancelSheet({
   sessionId,
   close,
 }: {
@@ -16,7 +16,10 @@ export default function CancelSheet({
 
   const { mutate } = useSessionMutations().cancelMutation;
 
-  const REASONS = ["학부모 요청", "선생님 요청"] as const;
+  const CANCEL_REASON = [
+    { value: "PARENT", label: "학부모 요청" },
+    { value: "TEACHER", label: "선생님 요청" },
+  ] as const;
 
   const handleSubmit = () => {
     mutate({ sessionId, reason: selected });
@@ -40,7 +43,65 @@ export default function CancelSheet({
             휴강 사유를 선택해주세요.
           </h2>
           <div className="mb-[40px] flex flex-col gap-[32px]">
-            {REASONS.map((reason) => (
+            {CANCEL_REASON.map(({ value, label }) => (
+              <Radio
+                key={value}
+                label={label}
+                selected={selected === value}
+                onClick={() => setSelected(value)}
+              />
+            ))}
+          </div>
+
+          <Button disabled={!selected} onClick={handleSubmit}>
+            완료하기
+          </Button>
+        </>
+      )}
+    </>
+  );
+}
+
+export function SameDayCancelSheet({
+  sessionId,
+  close,
+}: {
+  sessionId: number;
+  close: () => void;
+}) {
+  const [confirmed, setConfirmed] = useState(false);
+  const [selected, setSelected] = useState("");
+
+  const { mutate } = useSessionMutations().cancelMutation;
+
+  const REASONS = {
+    TEACHER: "선생님 요청",
+    PARENT: "학부모 요청",
+  } as const;
+
+  const handleSubmit = () => {
+    mutate({ sessionId, reason: selected });
+    close();
+  };
+
+  return (
+    <>
+      {!confirmed && (
+        <>
+          <h2 className="mb-[24px] mt-[4px] text-[20px] font-bold">
+            학부모님과 상의 후에 <br />
+            휴강을 결정했나요?
+          </h2>
+          <Button onClick={() => setConfirmed(true)}>네 맞아요</Button>
+        </>
+      )}
+      {confirmed && (
+        <>
+          <h2 className="mb-[24px] mt-[4px] text-[20px] font-bold">
+            휴강 사유를 선택해주세요.
+          </h2>
+          <div className="mb-[40px] flex flex-col gap-[32px]">
+            {Object.values(REASONS).map((reason) => (
               <Radio
                 key={reason}
                 label={reason}

--- a/app/components/teacher/SessionList/CancelSheet.tsx
+++ b/app/components/teacher/SessionList/CancelSheet.tsx
@@ -4,6 +4,7 @@ import Button from "@/ui/Button";
 import Radio from "@/ui/Radio";
 import { useSessionMutations } from "@/hooks/mutation/usePatchSessions";
 import { CANCEL_TEXT } from "@/constants/session/cancel";
+import { CancelReason } from "@/actions/patch-sessions";
 
 export function NotSameDayCancelSheet({
   sessionId,
@@ -64,16 +65,14 @@ export function NotSameDayCancelSheet({
 }
 
 export function SameDayCancelSheet({
-  sessionId,
   close,
+  onRequestCancel,
 }: {
-  sessionId: number;
   close: () => void;
+  onRequestCancel: (reason: CancelReason) => void;
 }) {
   const [confirmed, setConfirmed] = useState(false);
-  const [selected, setSelected] = useState("");
-
-  const { mutate } = useSessionMutations().cancelMutation;
+  const [selected, setSelected] = useState<CancelReason | null>(null);
 
   const CANCEL_REASONS = [
     {
@@ -93,9 +92,9 @@ export function SameDayCancelSheet({
     },
   ] as const;
 
-  // TODO: 완료하기 누르면 당일휴강은 취소할 수 없다는 alert 모달
   const handleSubmit = () => {
-    mutate({ sessionId, reason: selected });
+    if (!selected) return;
+    onRequestCancel(selected);
     close();
   };
 

--- a/app/components/teacher/SessionList/CancelSheet.tsx
+++ b/app/components/teacher/SessionList/CancelSheet.tsx
@@ -24,7 +24,7 @@ export function NotSameDayCancelSheet({
   ] as const;
 
   const handleSubmit = () => {
-    mutate({ sessionId, reason: selected });
+    mutate({ sessionId, reason: selected, isTodayCancel: false });
     close();
   };
 
@@ -79,16 +79,19 @@ export function SameDayCancelSheet({
       value: "TOGETHER",
       label: CANCEL_TEXT.NOT_SAME_DAY_CANCEL,
       description: "",
+      isTodayCancel: false,
     },
     {
       value: "PARENT",
       label: CANCEL_TEXT.SAME_DAY_CANCEL_BY_PARENTS_LONG,
       description: CANCEL_TEXT.SAME_DAY_CANCEL_BY_PARENTS_DESC,
+      isTodayCancel: true,
     },
     {
       value: "TEACHER",
       label: CANCEL_TEXT.SAME_DAY_CANCEL_BY_TEACHER_LONG,
       description: CANCEL_TEXT.SAME_DAY_CANCEL_BY_TEACHER_DESC,
+      isTodayCancel: true,
     },
   ] as const;
 

--- a/app/components/teacher/SessionList/index.tsx
+++ b/app/components/teacher/SessionList/index.tsx
@@ -120,6 +120,7 @@ export default function SessionList({ classId }: SessionListProps) {
               initialOpen={idx < 3}
               currentRound={session.currentRound}
               maxRound={session.maxRound}
+              cancel={session.cancel}
             />
           ))}
 

--- a/app/components/teacher/SessionList/useSessionList.ts
+++ b/app/components/teacher/SessionList/useSessionList.ts
@@ -10,6 +10,7 @@ import {
   BTN_VIEW_REVIEW,
 } from "@/ui/Card/SessionListCard/ActionButtons";
 import { CancelReason } from "@/actions/patch-sessions";
+import { CANCEL_TEXT } from "@/constants/session/cancel";
 
 export interface SessionItem {
   id: number;
@@ -66,10 +67,10 @@ export function useSessionList(data: SessionResponse[]): SessionItem[] {
 
       switch (true) {
         case isTodayCancel && cancelReason === "TEACHER":
-          statusLabel = "선생님 당일휴강";
+          statusLabel = CANCEL_TEXT.SAME_DAY_CANCEL_BY_TEACHER_SHORT;
           break;
         case isTodayCancel && cancelReason === "PARENT":
-          statusLabel = "학부모 당일휴강";
+          statusLabel = CANCEL_TEXT.SAME_DAY_CANCEL_BY_PARENTS_SHORT;
           break;
         case cancel:
           statusLabel = "휴강";

--- a/app/components/teacher/SessionList/useSessionList.ts
+++ b/app/components/teacher/SessionList/useSessionList.ts
@@ -9,6 +9,7 @@ import {
   BTN_RESCHEDULE,
   BTN_VIEW_REVIEW,
 } from "@/ui/Card/SessionListCard/ActionButtons";
+import { CancelReason } from "@/actions/patch-sessions";
 
 export interface SessionItem {
   id: number;
@@ -20,6 +21,8 @@ export interface SessionItem {
   complete: boolean;
   currentRound?: number;
   maxRound?: number;
+  isTodayCancel?: boolean;
+  cancelReason?: CancelReason;
 }
 
 export function useSessionList(data: SessionResponse[]): SessionItem[] {
@@ -36,6 +39,8 @@ export function useSessionList(data: SessionResponse[]): SessionItem[] {
         classStart,
         currentRound,
         maxRound,
+        isTodayCancel,
+        cancelReason,
       } = session;
 
       // Date 객체 생성 및 시간 포맷
@@ -59,12 +64,22 @@ export function useSessionList(data: SessionResponse[]): SessionItem[] {
       let actions: ActionButton[] = [];
 
       switch (true) {
+        case isTodayCancel && cancelReason === "TEACHER":
+          statusLabel = "선생님 당일휴강";
+          break;
+        case isTodayCancel && cancelReason === "PARENT":
+          statusLabel = "학부모 당일휴강";
+          break;
         case cancel:
           statusLabel = "휴강";
           actions = [BTN_CANCEL_RESTORE];
           break;
         case complete:
           actions = [BTN_VIEW_REVIEW];
+          break;
+        case isTodayCancel && cancelReason === "TOGETHER":
+          statusLabel = "당일 휴강";
+          actions = [BTN_CANCEL_RESTORE];
           break;
         case isToday:
           statusLabel = "오늘";

--- a/app/components/teacher/SessionList/useSessionList.ts
+++ b/app/components/teacher/SessionList/useSessionList.ts
@@ -23,6 +23,7 @@ export interface SessionItem {
   maxRound?: number;
   isTodayCancel?: boolean;
   cancelReason?: CancelReason;
+  cancel?: boolean;
 }
 
 export function useSessionList(data: SessionResponse[]): SessionItem[] {
@@ -103,6 +104,7 @@ export function useSessionList(data: SessionResponse[]): SessionItem[] {
         complete,
         currentRound,
         maxRound,
+        cancel,
       };
     });
 

--- a/app/constants/session/cancel.ts
+++ b/app/constants/session/cancel.ts
@@ -1,0 +1,13 @@
+export const CANCEL_TEXT = {
+  SELECT_CANCEL_REASON: "휴강 사유를 선택해주세요",
+  SAME_DAY_CANCEL_BY_TEACHER_SHORT: "선생님 당일휴강",
+  SAME_DAY_CANCEL_BY_PARENTS_SHORT: "학부모 당일휴강",
+  SAME_DAY_CANCEL_BY_TEACHER_LONG: "선생님 요청에 의한 당일 휴강",
+  SAME_DAY_CANCEL_BY_PARENTS_LONG: "학부모 요청에 의한 당일 휴강",
+  SAME_DAY_CANCEL_BY_TEACHER_DESC: "별도의 무료 보강 수업을 제공해야 해요",
+  SAME_DAY_CANCEL_BY_PARENTS_DESC:
+    "진행한 수업으로 처리되어, 정산 받을 수 있어요",
+  NOT_SAME_DAY_CANCEL: "당일 이전 합의된 휴강",
+  SAME_DAY_CANCEL_ALERT: `당일 휴강은 취소할 수 없어요.\n그래도 진행할까요?`,
+  SAME_DAY_CANCEL_SUCCESS: "당일휴강 처리 됐어요",
+} as const;

--- a/app/constants/session/cancel.ts
+++ b/app/constants/session/cancel.ts
@@ -2,6 +2,8 @@ export const CANCEL_TEXT = {
   SELECT_CANCEL_REASON: "휴강 사유를 선택해주세요",
   SAME_DAY_CANCEL_BY_TEACHER_SHORT: "선생님 당일휴강",
   SAME_DAY_CANCEL_BY_PARENTS_SHORT: "학부모 당일휴강",
+  SAME_DAY_CANCEL_BY_TEACHER_REQUEST: "선생님 요청",
+  SAME_DAY_CANCEL_BY_PARENTS_REQUEST: "학부모 요청",
   SAME_DAY_CANCEL_BY_TEACHER_LONG: "선생님 요청에 의한 당일 휴강",
   SAME_DAY_CANCEL_BY_PARENTS_LONG: "학부모 요청에 의한 당일 휴강",
   SAME_DAY_CANCEL_BY_TEACHER_DESC: "별도의 무료 보강 수업을 제공해야 해요",

--- a/app/ui/Card/SessionListCard/index.tsx
+++ b/app/ui/Card/SessionListCard/index.tsx
@@ -9,7 +9,10 @@ import cn from "@/utils/cn";
 import BottomSheet from "@/ui/BottomSheet";
 import { useBottomSheet } from "@/components/teacher/SessionList/useBottomSheet";
 import RescheduleSheet from "@/components/teacher/SessionList/RescheduleSheet";
-import CancelSheet from "@/components/teacher/SessionList/CancelSheet";
+import {
+  NotSameDayCancelSheet,
+  SameDayCancelSheet,
+} from "@/components/teacher/SessionList/CancelSheet";
 import RevertSheet from "@/components/teacher/SessionList/RevertSheet";
 import Badge from "@/ui/Badge";
 
@@ -48,6 +51,15 @@ export default function SessionListCard({
   const router = useRouter();
   const searchParams = useSearchParams();
   const { sheetType, openSheet, closeSheet, isSheetOpen } = useBottomSheet();
+
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+
+  const sessionDate = new Date(date);
+  sessionDate.setHours(0, 0, 0, 0);
+
+  // 오늘 포함 이전 날짜인지 확인하는 변수
+  const isTodayOrPast = sessionDate <= today;
 
   const defaultOpen =
     initialOpen ||
@@ -170,9 +182,15 @@ export default function SessionListCard({
             close={closeSheet}
           />
         )}
-        {sheetType === "cancel" && (
-          <CancelSheet sessionId={classSessionId} close={closeSheet} />
-        )}
+        {sheetType === "cancel" &&
+          (isTodayOrPast ? (
+            <SameDayCancelSheet sessionId={classSessionId} close={closeSheet} />
+          ) : (
+            <NotSameDayCancelSheet
+              sessionId={classSessionId}
+              close={closeSheet}
+            />
+          ))}
         {sheetType === "cancel_restore" && (
           <RevertSheet sessionId={classSessionId} close={closeSheet} />
         )}

--- a/app/ui/Card/SessionListCard/index.tsx
+++ b/app/ui/Card/SessionListCard/index.tsx
@@ -39,6 +39,7 @@ export interface SessionListCardProps {
   initialOpen?: boolean;
   currentRound?: number;
   maxRound?: number;
+  cancel?: boolean;
 }
 
 export default function SessionListCard({
@@ -52,6 +53,7 @@ export default function SessionListCard({
   initialOpen = false,
   currentRound,
   maxRound,
+  cancel = false,
 }: SessionListCardProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -116,6 +118,27 @@ export default function SessionListCard({
     [router, searchParams, classSessionId, openSheet],
   );
 
+  // Badge 표시 조건을 명확하게 분리
+  const shouldShowBadge = (() => {
+    // 당일휴강 상태면 Badge 안 보임
+    if (
+      statusLabel === "선생님 당일휴강" ||
+      statusLabel === "학부모 당일휴강"
+    ) {
+      return false;
+    }
+
+    // cancel이 true이고 currentRound가 0이면 Badge 안 보임
+    if (cancel && currentRound === 0) {
+      return false;
+    }
+
+    // currentRound와 maxRound가 유효한 값이어야 Badge 보임
+    return (
+      currentRound !== undefined && maxRound !== undefined && currentRound >= 0
+    );
+  })();
+
   return (
     <div
       className={cn(
@@ -162,30 +185,25 @@ export default function SessionListCard({
             </span>
           )}
         </div>
-        {statusLabel !== "선생님 당일휴강" &&
-          statusLabel !== "학부모 당일휴강" && (
-            <div className="flex items-center">
-              {currentRound !== undefined &&
-                maxRound !== undefined &&
-                currentRound > 0 && (
-                  <Badge className={cn(isToggle && "mr-2")}>
-                    {maxRound ?? "-"}회 중{" "}
-                    <strong className="ml-1 font-semibold">
-                      {currentRound ?? "-"}회
-                    </strong>
-                  </Badge>
-                )}
-              {currentRound !== undefined && currentRound === 0 && (
-                <Badge>무료보강</Badge>
-              )}
-              <IconDown
-                className={cn({
-                  hidden: !isToggle,
-                  "rotate-180": isOpen,
-                })}
-              />
-            </div>
-          )}
+        {shouldShowBadge && currentRound !== undefined && (
+          <div className="flex items-center">
+            {currentRound > 0 && (
+              <Badge className={cn(isToggle && "mr-2")}>
+                {maxRound ?? "-"}회 중{" "}
+                <strong className="ml-1 font-semibold">
+                  {currentRound ?? "-"}회
+                </strong>
+              </Badge>
+            )}
+            {currentRound === 0 && <Badge>무료보강</Badge>}
+            <IconDown
+              className={cn({
+                hidden: !isToggle,
+                "rotate-180": isOpen,
+              })}
+            />
+          </div>
+        )}
       </div>
       {showMoneyReminder && (
         <p className="text-[14px] text-gray-500">

--- a/app/ui/Card/SessionListCard/index.tsx
+++ b/app/ui/Card/SessionListCard/index.tsx
@@ -78,7 +78,11 @@ export default function SessionListCard({
 
   const cancelSameDaySession = () => {
     if (!cancelReason) return;
-    mutate({ sessionId: classSessionId, reason: cancelReason });
+    mutate({
+      sessionId: classSessionId,
+      reason: cancelReason,
+      isTodayCancel: cancelReason !== "TOGETHER",
+    });
     closeModal();
   };
 

--- a/app/ui/Card/SessionListCard/index.tsx
+++ b/app/ui/Card/SessionListCard/index.tsx
@@ -15,6 +15,11 @@ import {
 } from "@/components/teacher/SessionList/CancelSheet";
 import RevertSheet from "@/components/teacher/SessionList/RevertSheet";
 import Badge from "@/ui/Badge";
+import { CancelReason } from "@/actions/patch-sessions";
+import { useModal } from "@/hooks/custom";
+import { useSessionMutations } from "@/hooks/mutation/usePatchSessions";
+import { Modal } from "@/ui/Modal/Modal";
+import { CANCEL_TEXT } from "@/constants/session/cancel";
 
 export interface ActionButton {
   label: string;
@@ -51,6 +56,9 @@ export default function SessionListCard({
   const router = useRouter();
   const searchParams = useSearchParams();
   const { sheetType, openSheet, closeSheet, isSheetOpen } = useBottomSheet();
+  const [cancelReason, setCancelReason] = useState<CancelReason | null>(null);
+  const { isModalOpen, openModal, closeModal } = useModal();
+  const { mutate } = useSessionMutations().cancelMutation;
 
   const today = new Date();
   today.setHours(0, 0, 0, 0);
@@ -67,6 +75,18 @@ export default function SessionListCard({
     actions.some((btn) => btn.value === "view_review");
   const [isOpen, setIsOpen] = useState(defaultOpen);
   const isToggle = !defaultOpen;
+
+  const cancelSameDaySession = () => {
+    if (!cancelReason) return;
+    mutate({ sessionId: classSessionId, reason: cancelReason });
+    closeModal();
+  };
+
+  const handleSameDayCancel = (reason: CancelReason) => {
+    setCancelReason(reason);
+    closeSheet();
+    openModal();
+  };
 
   const handleActionClick = useCallback(
     (value: string) => {
@@ -107,7 +127,6 @@ export default function SessionListCard({
       >
         <div className="flex flex-col">
           <div className="flex items-center">
-            {/* "휴강" 또는 "오늘"만 날짜 왼쪽에 */}
             {(statusLabel === "휴강" || statusLabel === "오늘") && (
               <span
                 className={cn(
@@ -126,7 +145,6 @@ export default function SessionListCard({
               )} ${time}`}
             </span>
           </div>
-          {/* "선생님 당일휴강" 또는 "학부모 당일휴강"만 날짜 아래에 빨간색으로 */}
           {(statusLabel === "선생님 당일휴강" ||
             statusLabel === "학부모 당일휴강") && (
             <span className="mt-1 text-[15px] font-semibold text-red-500">
@@ -195,7 +213,10 @@ export default function SessionListCard({
         )}
         {sheetType === "cancel" &&
           (isTodayOrPast ? (
-            <SameDayCancelSheet sessionId={classSessionId} close={closeSheet} />
+            <SameDayCancelSheet
+              close={closeSheet}
+              onRequestCancel={handleSameDayCancel}
+            />
           ) : (
             <NotSameDayCancelSheet
               sessionId={classSessionId}
@@ -206,6 +227,14 @@ export default function SessionListCard({
           <RevertSheet sessionId={classSessionId} close={closeSheet} />
         )}
       </BottomSheet>
+      <Modal
+        isOpen={isModalOpen}
+        title={CANCEL_TEXT.SAME_DAY_CANCEL_ALERT}
+        handleOnConfirm={cancelSameDaySession}
+        handleOnCancel={closeModal}
+        confirmText="진행할게요"
+        cancelText="아니요"
+      />
     </div>
   );
 }

--- a/app/ui/Card/SessionListCard/index.tsx
+++ b/app/ui/Card/SessionListCard/index.tsx
@@ -89,7 +89,13 @@ export default function SessionListCard({
   const handleSameDayCancel = (reason: CancelReason) => {
     setCancelReason(reason);
     closeSheet();
-    openModal();
+    if (reason === "PARENT" || reason === "TEACHER") openModal();
+    if (reason === "TOGETHER")
+      mutate({
+        sessionId: classSessionId,
+        reason,
+        isTodayCancel: false,
+      });
   };
 
   const handleActionClick = useCallback(

--- a/app/ui/Card/SessionListCard/index.tsx
+++ b/app/ui/Card/SessionListCard/index.tsx
@@ -36,7 +36,6 @@ export interface SessionListCardProps {
   maxRound?: number;
 }
 
-// TODO: 당일휴강된 카드는 UI 달라야 됨 (취소 안됨)
 export default function SessionListCard({
   classSessionId,
   date,
@@ -106,41 +105,52 @@ export default function SessionListCard({
           isOpen ? "mb-1" : "mb-0",
         )}
       >
-        <div className="flex items-center">
-          {statusLabel && (
-            <span
-              className={cn(
-                "mr-2 text-[16px] font-semibold",
-                statusLabel === "오늘" && "text-primary",
-                statusLabel === "휴강" && "text-red-500",
-              )}
-            >
+        <div className="flex flex-col">
+          <div className="flex items-center">
+            {/* "휴강" 또는 "오늘"만 날짜 왼쪽에 */}
+            {(statusLabel === "휴강" || statusLabel === "오늘") && (
+              <span
+                className={cn(
+                  "mr-2 text-[16px] font-semibold",
+                  statusLabel === "오늘" && "text-primary",
+                  statusLabel === "휴강" && "text-red-500",
+                )}
+              >
+                {statusLabel}
+              </span>
+            )}
+            <span className="text-[16px] font-[600] text-gray-900">
+              {`${date.getMonth() + 1}.${date.getDate()} ${date.toLocaleDateString(
+                "ko-KR",
+                { weekday: "long" },
+              )} ${time}`}
+            </span>
+          </div>
+          {/* "선생님 당일휴강" 또는 "학부모 당일휴강"만 날짜 아래에 빨간색으로 */}
+          {(statusLabel === "선생님 당일휴강" ||
+            statusLabel === "학부모 당일휴강") && (
+            <span className="mt-1 text-[15px] font-semibold text-red-500">
               {statusLabel}
             </span>
           )}
-          <span className="text-[16px] font-[600] text-gray-900">
-            {`${date.getMonth() + 1}.${date.getDate()} ${date.toLocaleDateString(
-              "ko-KR",
-              {
-                weekday: "long",
-              },
-            )} ${time}`}
-          </span>
         </div>
-        <div className="flex items-center">
-          <Badge className={cn(isToggle && "mr-2")}>
-            {maxRound ?? "-"}회 중{" "}
-            <strong className="ml-1 font-semibold">
-              {currentRound ?? "-"}회
-            </strong>
-          </Badge>
-          <IconDown
-            className={cn({
-              hidden: !isToggle,
-              "rotate-180": isOpen,
-            })}
-          />
-        </div>
+        {statusLabel !== "선생님 당일휴강" &&
+          statusLabel !== "학부모 당일휴강" && (
+            <div className="flex items-center">
+              <Badge className={cn(isToggle && "mr-2")}>
+                {maxRound ?? "-"}회 중{" "}
+                <strong className="ml-1 font-semibold">
+                  {currentRound ?? "-"}회
+                </strong>
+              </Badge>
+              <IconDown
+                className={cn({
+                  hidden: !isToggle,
+                  "rotate-180": isOpen,
+                })}
+              />
+            </div>
+          )}
       </div>
       {showMoneyReminder && (
         <p className="text-[14px] text-gray-500">

--- a/app/ui/Card/SessionListCard/index.tsx
+++ b/app/ui/Card/SessionListCard/index.tsx
@@ -165,12 +165,19 @@ export default function SessionListCard({
         {statusLabel !== "선생님 당일휴강" &&
           statusLabel !== "학부모 당일휴강" && (
             <div className="flex items-center">
-              <Badge className={cn(isToggle && "mr-2")}>
-                {maxRound ?? "-"}회 중{" "}
-                <strong className="ml-1 font-semibold">
-                  {currentRound ?? "-"}회
-                </strong>
-              </Badge>
+              {currentRound !== undefined &&
+                maxRound !== undefined &&
+                currentRound > 0 && (
+                  <Badge className={cn(isToggle && "mr-2")}>
+                    {maxRound ?? "-"}회 중{" "}
+                    <strong className="ml-1 font-semibold">
+                      {currentRound ?? "-"}회
+                    </strong>
+                  </Badge>
+                )}
+              {currentRound !== undefined && currentRound === 0 && (
+                <Badge>무료보강</Badge>
+              )}
               <IconDown
                 className={cn({
                   hidden: !isToggle,

--- a/app/ui/Card/SessionListCard/index.tsx
+++ b/app/ui/Card/SessionListCard/index.tsx
@@ -36,6 +36,7 @@ export interface SessionListCardProps {
   maxRound?: number;
 }
 
+// TODO: 당일휴강된 카드는 UI 달라야 됨 (취소 안됨)
 export default function SessionListCard({
   classSessionId,
   date,

--- a/app/ui/Modal/Modal.tsx
+++ b/app/ui/Modal/Modal.tsx
@@ -4,8 +4,8 @@ import { useRef } from "react";
 import { useClickoutside } from "app/hooks/custom";
 
 export interface ModalProps {
-  title: string | React.ReactNode;
-  message: React.ReactNode;
+  title?: string | React.ReactNode;
+  message?: React.ReactNode;
   confirmText: string;
   cancelText?: string;
   handleOnConfirm: () => void;
@@ -27,21 +27,28 @@ export function Modal({
     return null;
   }
 
+  // TODO: 모달 쓰이는 다른 곳에서 UI 안 깨지는지 확인 필요함 !!
   return (
     <div className="fixed inset-0 z-10 flex items-center justify-center bg-black/50">
       <div
         ref={modalRef}
         className="w-1/3 min-w-[335px] rounded-[20px] bg-white p-6 shadow-lg"
       >
-        <h2 className="mb-2 text-center text-lg font-semibold">{title}</h2>
-        <p className="mb-5 whitespace-pre text-center text-sm font-medium text-gray-500">
-          {message}
-        </p>
-        <div className="flex justify-center">
+        {title && (
+          <h2 className="mb-2 whitespace-pre text-center text-lg font-semibold">
+            {title}
+          </h2>
+        )}
+        {message && (
+          <p className="mb-5 whitespace-pre text-center text-sm font-medium text-gray-500">
+            {message}
+          </p>
+        )}
+        <div className="flex justify-between gap-[7px]">
           {rest.cancelText && (
             <button
               onClick={rest.handleOnCancel}
-              className="mr-2 min-h-[52px] rounded-xl bg-primaryTint px-4 py-2 font-semibold text-primaryNormal"
+              className="mr-2 min-h-[52px] w-full rounded-xl bg-primaryTint px-4 py-2 font-semibold text-primaryNormal"
             >
               {rest.cancelText}
             </button>
@@ -49,7 +56,7 @@ export function Modal({
 
           <button
             onClick={rest.handleOnConfirm}
-            className="min-h-[52px] rounded-xl bg-primaryNormal px-4 py-2 font-semibold text-white"
+            className="min-h-[52px] w-full rounded-xl bg-primaryNormal px-4 py-2 font-semibold text-white"
           >
             {rest.confirmText}
           </button>

--- a/app/ui/Radio/index.tsx
+++ b/app/ui/Radio/index.tsx
@@ -3,7 +3,7 @@
 import IconRoundCheck from "@/icons/IconRoundCheck";
 
 interface CustomRadioProps {
-  label: string;
+  label: React.ReactNode;
   subLabel?: string;
   selected: boolean;
   onClick?: () => void;
@@ -23,7 +23,7 @@ export default function Radio({
       role="radio"
       aria-checked={selected}
     >
-      <div className="flex items-center gap-[8px]">
+      <div className="flex items-center gap-2">
         <IconRoundCheck isFill={selected} />
         <span className="text-gray-700">{label}</span>
       </div>


### PR DESCRIPTION
## 🐈 PR 요약
> PR 내용 한 줄로 요약
- 관련 테크스펙 링크 : x
- 학부모/선생님 당일휴강 flow 개발

## ✨ PR 상세
> PR 상세 내용 개조식으로 작성
- 휴강 api가 `reason`, `isTodayCancel`을 body에 담아 보내주는 로직으로 변경되어 수정함
- 이제 `reason`은 string이 아니라 `"TOGETHER" | "PARENT" | "TEACHER"` 중 하나로 보내야 해서 union 타입으로 정의
- 오늘포함 이전날짜 수업 휴강 -> 당일휴강 처리가 가능한 바텀시트
- 오늘제외 이후날짜 수업 휴강 -> 기존 휴강처리 바텀시트
- `학부모 당일휴강`, `선생님 당일휴강`인 경우 회차 다시 계산해서 display
- 당일휴강 -> 당일휴강 취소불가 모달 보여주기

## 🚨 참고사항
> 리뷰어들이 알아야 하거나 알면 좋은 참고사항 작성
- 학부모 당일휴강이면 해당 수업은 회차 차감 처리(회차 카운트) + 선생님 당일휴강이면 해당 수업 다음 수업 중 첫번째 active한 수업이 '무료보강' 처리, 그 다음 수업부터 회차 이어서 출력 -> 이게 생각보다 너무 복잡해서 오래걸렸네요 ㅠㅠ 당일휴강이 있으면 모든 수업 회차를 다 다시 계산해줘야 되더라구요,,,

## 📸 스크린샷
> 화면 캡쳐 이미지
<img width="300" height="579" alt="image" src="https://github.com/user-attachments/assets/630cb58b-7a87-4a62-a7a0-041ae6fa6e9e" />
<img width="320" height="538" alt="image" src="https://github.com/user-attachments/assets/fbba85ec-f97c-4f63-82ed-468b46695eed" />

## ✅ 체크리스트
- [x] Reviewers 태그했나요?
- [x] Label 지정했나요?
- [ ] 관련 테크스펙 링크 연결했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 당일/비당일을 구분한 별도 취소 시트(2단계 확인 및 이유 선택)와 취소 플로우 도입.
  * 취소 사유(교사/학부모/동의) 및 당일 여부 플래그를 포함한 취소 처리 지원.

* **개선 사항**
  * 세션 목록·카드에 당일 취소 라벨과 배지 로직 반영으로 상태 표시 개선.
  * 모달·라디오 컴포넌트의 유연성 및 선택 유효성 강화.

* **버그 수정**
  * 취소 사유 선택 및 제출 안정성 향상.

* **문서화**
  * 취소 관련 안내 문구(상세 텍스트) 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->