### PR TITLE
[feat] 어드민에서 "이 선생님과 할래요" flow 추가

### DIFF
--- a/app/(route)/(admin)/zuzuclubadmin/[id]/(hooks)/useAlimTable.tsx
+++ b/app/(route)/(admin)/zuzuclubadmin/[id]/(hooks)/useAlimTable.tsx
@@ -74,7 +74,12 @@ export const AlimTableProvider = ({
 
   return (
     <AlimTableContext.Provider
-      value={{ matchingId, alimTable, rowSelection, setRowSelection }}
+      value={{
+        matchingId,
+        alimTable,
+        rowSelection,
+        setRowSelection,
+      }}
     >
       {children}
     </AlimTableContext.Provider>

--- a/app/actions/get-admin-details-matching-recommend/index.ts
+++ b/app/actions/get-admin-details-matching-recommend/index.ts
@@ -1,0 +1,15 @@
+import { httpService } from "app/utils/httpService";
+
+interface AdminMatchingRecommendParams {
+  classMatchingId: string;
+}
+
+export async function getAdminMatchingRecommend(
+  params: AdminMatchingRecommendParams,
+) {
+  const response = await httpService.get<string>(
+    `/admin/details/matching/recommend?classMatchingId=${params.classMatchingId}`,
+  );
+
+  return response.data;
+}

--- a/app/components/admin/AlimHeader.tsx
+++ b/app/components/admin/AlimHeader.tsx
@@ -86,6 +86,11 @@ export function AlimHeader({ matchingId }: AlimHeaderProps) {
       return;
     }
 
+    if (selectedRows.length > 1) {
+      alert("선생님을 1명만 선택해주세요.");
+      return;
+    }
+
     if (!targetTeacher) {
       alert("선택된 선생님이 없습니다.");
       return;

--- a/app/components/admin/AlimHeader.tsx
+++ b/app/components/admin/AlimHeader.tsx
@@ -12,6 +12,7 @@ import { useModal } from "@/hooks/custom";
 import { Modal } from "@/ui";
 import { useAlimTableContext } from "@/(route)/(admin)/zuzuclubadmin/[id]/(hooks)/useAlimTable";
 import { formatTimetoDate } from "@/utils/formatTimetoDate";
+import { useGetAdminMatchingRecommend } from "@/hooks/query/useGetAdminMatchingRecommend";
 
 interface AlimHeaderProps {
   matchingId: string;
@@ -19,17 +20,40 @@ interface AlimHeaderProps {
 
 export function AlimHeader({ matchingId }: AlimHeaderProps) {
   const { data: alimData } = useGetAcceptance(matchingId, 1);
-  const { isModalOpen, closeModal, openModal } = useModal();
+  const { isModalOpen, closeModal, openModal } = useModal(); // "선생님 추천 발송" 모달
+  const {
+    isModalOpen: isRecommendModalOpen,
+    closeModal: closeRecommendModal,
+    openModal: openRecommendModal,
+  } = useModal(); // "이 선생님과 할래요" 모달
   const { mutate: postMatchingAcceptance } = usePostMatchingAcceptance();
   const { alimTable, rowSelection } = useAlimTableContext();
 
   const queryClient = useQueryClient();
 
-  const selectedRowNickName = alimTable
-    .getSelectedRowModel()
-    .flatRows.map((v) => {
-      return v.original.nickName;
-    });
+  const selectedRows = alimTable.getSelectedRowModel().flatRows;
+  const selectedRowNickName = selectedRows.map((row) => row.original.nickName);
+
+  // "이 선생님과 할래요"에서 사용할 대상 선생님 정보 가져오기
+  const getTargetTeacher = () => {
+    if (selectedRows.length === 0) return null;
+
+    /**
+     * 1. 선택된 유효한 선생님이 1명이면 해당 선생님
+     * 2. 선택된 유효한 선생님이 n명이면 마지막으로 선택된 선생님
+     */
+    const targetRow = selectedRows[selectedRows.length - 1];
+    return {
+      classMatchingId: String(targetRow.original.classMatchingId),
+      nickName: targetRow.original.nickName,
+      status: targetRow.original.status,
+    };
+  };
+
+  const targetTeacher = getTargetTeacher();
+  const { data: adminMatchingRecommend } = useGetAdminMatchingRecommend(
+    targetTeacher?.classMatchingId || null,
+  );
 
   const acceptanceQueryMutate = () => {
     const existAcceptanceQueryData = queryClient.getQueryData<AcceptanceSchema>(
@@ -56,6 +80,42 @@ export function AlimHeader({ matchingId }: AlimHeaderProps) {
     queryClient.setQueryData([`/acceptance/${matchingId}/1`], newQueryData);
   };
 
+  const handleTeacherRecommend = () => {
+    if (selectedRows.length === 0) {
+      alert("선생님을 먼저 선택해주세요.");
+      return;
+    }
+
+    if (!targetTeacher) {
+      alert("선택된 선생님이 없습니다.");
+      return;
+    }
+
+    // 매칭을 '수락'한 선생님한테만 '이 선생님과 할래요' 가능
+    if (targetTeacher.status !== "수락") {
+      alert("해당 선생님은 매칭을 수락하지 않았습니다.");
+      return;
+    }
+
+    openRecommendModal();
+  };
+
+  const handleTeacherConfirm = () => {
+    if (!adminMatchingRecommend) {
+      alert("추천 링크를 가져오는 중입니다. 잠시 후 다시 시도해주세요.");
+      return;
+    }
+
+    // 최종 매칭 페이지 새 탭으로 열기
+    if (typeof window !== "undefined") {
+      window.open(
+        `${window.location.origin}/teacher/recommend/${adminMatchingRecommend}`,
+        "_blank",
+      );
+    }
+    closeRecommendModal();
+  };
+
   return (
     <header className="mt-2 p-4">
       <div
@@ -74,18 +134,29 @@ export function AlimHeader({ matchingId }: AlimHeaderProps) {
             발송 후 {formatTimetoDate(alimData.time)} 경과
           </span>
         </div>
-        <button
-          onClick={() => {
-            if (Object.keys(rowSelection).length === 0) {
-              alert("학부모에게 추천할 선생님을 선택해주세요.");
-              return;
-            }
-            openModal();
-          }}
-          className="mr-4 rounded bg-primary px-3 py-[6px] font-normal text-white hover:bg-[#4762B4]"
-        >
-          선생님 추천 발송
-        </button>
+        <div>
+          <button
+            onClick={handleTeacherRecommend}
+            className="mr-4 rounded bg-orange-400 px-3 py-[6px] font-normal text-white hover:bg-orange-500 disabled:cursor-not-allowed disabled:bg-gray-300"
+            disabled={selectedRows.length === 0}
+          >
+            이 선생님과 할래요
+          </button>
+          <button
+            onClick={() => {
+              if (Object.keys(rowSelection).length === 0) {
+                alert("학부모에게 추천할 선생님을 선택해주세요.");
+                return;
+              }
+              openModal();
+            }}
+            className="mr-4 rounded bg-primary px-3 py-[6px] font-normal text-white hover:bg-[#4762B4]"
+          >
+            선생님 추천 발송
+          </button>
+        </div>
+
+        {/* 선생님 추천 발송 모달 */}
         <Modal
           isOpen={isModalOpen}
           handleOnConfirm={() => {
@@ -116,6 +187,17 @@ export function AlimHeader({ matchingId }: AlimHeaderProps) {
           message="위 선생님을 학부모께 정말 제안하시겠습니까?"
           confirmText="발송하기"
           cancelText="취소하기"
+        />
+
+        {/* 이 선생님과 할래요 모달 */}
+        <Modal
+          isOpen={isRecommendModalOpen}
+          handleOnConfirm={handleTeacherConfirm}
+          handleOnCancel={closeRecommendModal}
+          title="선생님 선택 확인"
+          message={`선택된 선생님은 "${targetTeacher?.nickName}"입니다. 이 선생님과 진행하시겠습니까?`}
+          confirmText="이 선생님과 할래요"
+          cancelText="아니요"
         />
       </div>
     </header>

--- a/app/components/admin/AlimHeader.tsx
+++ b/app/components/admin/AlimHeader.tsx
@@ -116,6 +116,7 @@ export function AlimHeader({ matchingId }: AlimHeaderProps) {
       window.open(
         `${window.location.origin}/teacher/recommend/${adminMatchingRecommend}`,
         "_blank",
+        "noopener,noreferrer",
       );
     }
     closeRecommendModal();

--- a/app/hooks/query/useGetAdminMatchingRecommend.ts
+++ b/app/hooks/query/useGetAdminMatchingRecommend.ts
@@ -1,0 +1,14 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { getAdminMatchingRecommend } from "app/actions/get-admin-details-matching-recommend";
+
+export function useGetAdminMatchingRecommend(classMatchingId: string | null) {
+  return useQuery({
+    queryKey: ["admin-matching-recommend", classMatchingId],
+    queryFn: () =>
+      getAdminMatchingRecommend({ classMatchingId: classMatchingId! }),
+    enabled: !!classMatchingId, // classMatchingId가 있을 때만 쿼리 실행
+    staleTime: 1000 * 60 * 5,
+    gcTime: 1000 * 60 * 10,
+  });
+}


### PR DESCRIPTION
## 🐈 PR 요약
> PR 내용 한 줄로 요약
- 관련 테크스펙 링크 : x
- 어드민에서도 최종 매칭 가능하게 수정

## ✨ PR 상세
> PR 상세 내용 개조식으로 작성
- 매칭관리에서 특정 매칭건으로 들어가면, 해당 화면에서 학부모와 최종 매칭 가능하게 기능 추가
- 선생님 선택하고 '이 선생님과 할래요' 누르면 "이 선생님과 진행하겠습니까?" 모달 등장
- 모달에서 "이 선생님과 할래요" 누르면 학부모에게 전송되는 '이 선생님과 할래요' 페이지로 이동 (새탭으로 열림)
- 해당 페이지에서 관리자가 시간 선택해서 제출 가능

## 🚨 참고사항
> 리뷰어들이 알아야 하거나 알면 좋은 참고사항 작성
- "이 선생님과 할래요"는 1명의 선생님과만 가능하지만, 같은 화면에 있는 "선생님 추천 발송"은 여러 명한테 가능해야 해서 행 선택이 여러 개 되는 걸 자체를 막을 수는 없었습니다!
- 대신 여러 명의 선생님 선택했을 때(매칭 상태가 '수락'인 선생님 중에)는 마지막으로 선택된 선생님 대상으로 모달이 뜨게 구현해두었습니다. 더 좋은 방법이 있다면 알려주세요!

## 📸 스크린샷
> 화면 캡쳐 이미지

https://github.com/user-attachments/assets/202af2b7-ca87-4840-912a-e0d2204b84f4


## ✅ 체크리스트
- [x] Reviewers 태그했나요?
- [x] Label 지정했나요?
- [ ] 관련 테크스펙 링크 연결했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 관리 페이지에 "이 선생님과 할래요" 버튼 및 추천 링크 확인 모달이 추가되었습니다.
  * 선택한 선생님에 대해 추천 링크를 조회하고, 확인 후 새 탭에서 링크를 열 수 있습니다.
  * 관리 추천 링크를 조회하는 새로운 API 및 React 쿼리 훅이 도입되었습니다.

* **버그 수정**
  * 선택된 선생님이 없거나 조건이 맞지 않을 때 적절한 안내 및 동작이 추가되었습니다.

* **스타일**
  * 일부 객체의 코드 포맷이 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->