### PR TITLE
fix: 수업 시간 라벨 텍스트 수정

### DIFF
--- a/app/components/result/ConfirmedResult/index.tsx
+++ b/app/components/result/ConfirmedResult/index.tsx
@@ -69,7 +69,7 @@ export default function ConfirmedResult() {
               return (
                 <DivWithLabel
                   key={day}
-                  label="수업 시간"
+                  label="회당 수업 시간"
                   subLabel={`(${day}요일)`}
                 >
                   <SelectButton
@@ -86,7 +86,14 @@ export default function ConfirmedResult() {
               );
             })
           ) : (
-            <DivWithLabel label="수업 시간">
+            <DivWithLabel
+              label={
+                <>
+                  회당 수업 시간{" "}
+                  <span className="font-normal text-primary">1회 기준</span>
+                </>
+              }
+            >
               <SelectButton
                 text={
                   commonSchedule &&

--- a/app/components/result/DivWithLabel.tsx
+++ b/app/components/result/DivWithLabel.tsx
@@ -1,7 +1,7 @@
 import cn from "@/utils/cn";
 
 interface DivWithLabelProps {
-  label: string;
+  label: React.ReactNode;
   subLabel?: string;
   children: React.ReactNode;
   className?: string;


### PR DESCRIPTION
## 🐈 PR 요약
> PR 내용 한 줄로 요약
- 관련 테크스펙 링크 : -

## ✨ PR 상세
> PR 상세 내용 개조식으로 작성

- 상담결과 공유 화면 > '수업시간' 텍스트 > '회당 수업시간' 으로 수정

## 🚨 참고사항
> 리뷰어들이 알아야 하거나 알면 좋은 참고사항 작성

- 라벨 일부 텍스트에만 색상이 추가되어야해서 컴포넌트에서 label=string 으로 받던 것을 react.reactnode로 변경했습니다.

## 📸 스크린샷
> 화면 캡쳐 이미지
<img width="295" height="412" alt="스크린샷 2025-08-03 오후 9 30 43" src="https://github.com/user-attachments/assets/3ca81b53-0cac-4f22-a94b-89e6f3064269" />

<img width="296" height="483" alt="스크린샷 2025-08-03 오후 9 30 36" src="https://github.com/user-attachments/assets/8b81fbf3-3548-4abc-9947-8f3ad3665312" />

## ✅ 체크리스트
- [ ] Reviewers 태그했나요?
- [ ] Label 지정했나요?
- [ ] 관련 테크스펙 링크 연결했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * "수업 시간" 라벨이 "회당 수업 시간"으로 변경되고, 단일 일정의 경우 "1회 기준" 안내 문구가 추가되었습니다.  
* **Refactor**
  * 라벨에 다양한 형태의 내용을 표시할 수 있도록 라벨 입력 형식이 확장되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->