### PR TITLE
fix: 매칭 상태 '전송'인 선생님한테만 '이 선생님과 할래요' 가능하게 변경

### DIFF
--- a/app/components/admin/AlimHeader.tsx
+++ b/app/components/admin/AlimHeader.tsx
@@ -98,7 +98,7 @@ export function AlimHeader({ matchingId }: AlimHeaderProps) {
 
     // 매칭 상태가 '전송'인 선생님한테만 '이 선생님과 할래요' 가능
     if (targetTeacher.status !== "전송") {
-      alert("학부모한테 전송된 선생님이 아닙니다.");
+      alert("학부모에게 전송된 선생님이 아닙니다.");
       return;
     }
 
@@ -144,7 +144,9 @@ export function AlimHeader({ matchingId }: AlimHeaderProps) {
           <button
             onClick={handleTeacherRecommend}
             className="mr-4 rounded bg-orange-400 px-3 py-[6px] font-normal text-white hover:bg-orange-500 disabled:cursor-not-allowed disabled:bg-gray-300"
-            disabled={selectedRows.length === 0}
+            disabled={
+              !(selectedRows.length === 1 && targetTeacher?.status === "전송")
+            }
           >
             이 선생님과 할래요
           </button>

--- a/app/components/admin/AlimHeader.tsx
+++ b/app/components/admin/AlimHeader.tsx
@@ -96,9 +96,9 @@ export function AlimHeader({ matchingId }: AlimHeaderProps) {
       return;
     }
 
-    // 매칭을 '수락'한 선생님한테만 '이 선생님과 할래요' 가능
-    if (targetTeacher.status !== "수락") {
-      alert("해당 선생님은 매칭을 수락하지 않았습니다.");
+    // 매칭 상태가 '전송'인 선생님한테만 '이 선생님과 할래요' 가능
+    if (targetTeacher.status !== "전송") {
+      alert("학부모한테 전송된 선생님이 아닙니다.s");
       return;
     }
 

--- a/app/components/admin/AlimHeader.tsx
+++ b/app/components/admin/AlimHeader.tsx
@@ -98,7 +98,7 @@ export function AlimHeader({ matchingId }: AlimHeaderProps) {
 
     // 매칭 상태가 '전송'인 선생님한테만 '이 선생님과 할래요' 가능
     if (targetTeacher.status !== "전송") {
-      alert("학부모한테 전송된 선생님이 아닙니다.s");
+      alert("학부모한테 전송된 선생님이 아닙니다.");
       return;
     }
 


### PR DESCRIPTION
## 🐈 PR 요약
> PR 내용 한 줄로 요약
- 관련 테크스펙 링크 : x

## ✨ PR 상세
> PR 상세 내용 개조식으로 작성
- 매칭 상태 '전송'인 선생님한테만 "이 선생님과 할래요" 가능해야 하는데 '수락'으로 잘못 개발해서 수정합니다 ㅜㅜ

## 🚨 참고사항
> 리뷰어들이 알아야 하거나 알면 좋은 참고사항 작성

## 📸 스크린샷
> 화면 캡쳐 이미지

## ✅ 체크리스트
- [x] Reviewers 태그했나요?
- [x] Label 지정했나요?
- [ ] 관련 테크스펙 링크 연결했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


* **버그 수정**
  * "이 선생님과 할래요" 버튼의 활성화 조건이 변경되어, 이제 선생님 매칭 상태가 "전송"일 때만 사용할 수 있습니다.
  * 관련 안내 메시지가 실제 상황에 맞게 수정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->