### PR TITLE
fix: 이 선생님과 할래요 버튼 disabled 로직 수정

### DIFF
--- a/app/components/admin/AlimHeader.tsx
+++ b/app/components/admin/AlimHeader.tsx
@@ -4,6 +4,7 @@
 "use client";
 
 import { useQueryClient } from "@tanstack/react-query";
+import { useEffect, useState } from "react";
 
 import type { AcceptanceSchema } from "@/actions/get-acceptance";
 import { useGetAcceptance } from "@/hooks/query";
@@ -28,6 +29,8 @@ export function AlimHeader({ matchingId }: AlimHeaderProps) {
   } = useModal(); // "이 선생님과 할래요" 모달
   const { mutate: postMatchingAcceptance } = usePostMatchingAcceptance();
   const { alimTable, rowSelection } = useAlimTableContext();
+  const [isRecommendButtonDisabled, setIsRecommendButtonDisabled] =
+    useState(true);
 
   const queryClient = useQueryClient();
 
@@ -54,6 +57,14 @@ export function AlimHeader({ matchingId }: AlimHeaderProps) {
   const { data: adminMatchingRecommend } = useGetAdminMatchingRecommend(
     targetTeacher?.classMatchingId || null,
   );
+
+  useEffect(() => {
+    if (selectedRows.length === 1 && targetTeacher?.status === "전송") {
+      setIsRecommendButtonDisabled(false);
+    } else {
+      setIsRecommendButtonDisabled(true);
+    }
+  }, [adminMatchingRecommend, selectedRows, targetTeacher]);
 
   const acceptanceQueryMutate = () => {
     const existAcceptanceQueryData = queryClient.getQueryData<AcceptanceSchema>(
@@ -144,9 +155,7 @@ export function AlimHeader({ matchingId }: AlimHeaderProps) {
           <button
             onClick={handleTeacherRecommend}
             className="mr-4 rounded bg-orange-400 px-3 py-[6px] font-normal text-white hover:bg-orange-500 disabled:cursor-not-allowed disabled:bg-gray-300"
-            disabled={
-              !(selectedRows.length === 1 && targetTeacher?.status === "전송")
-            }
+            disabled={isRecommendButtonDisabled}
           >
             이 선생님과 할래요
           </button>


### PR DESCRIPTION
## 🐈 PR 요약
> PR 내용 한 줄로 요약
- 관련 테크스펙 링크 : x
- '이 선생님과 할래요' 버튼 disabled 로직 일부 수정

## ✨ PR 상세
> PR 상세 내용 개조식으로 작성
- 매칭 상세 테이블에서 선생님을 선택해서 '선생님 추천 발송'을 하면 바로 해당 선생님이 '전송' 상태로 바뀌고, 선택된 상태가 유지되어 있음
- 그럼 이때 바로 '이 선생님과 할래요' 버튼이 활성화가 되어 있어야 하는데 비활성화 조건 업데이트가 안되어서 선생님 row를 선택 해제했다가 다시 선택해야 버튼이 활성화되는 버그가 있음
- 그래서 상태 바로 추적할 수 있도록 수정했습니다!

## 🚨 참고사항
> 리뷰어들이 알아야 하거나 알면 좋은 참고사항 작성
- 자주 있는 상황은 아닐 것 같지만 약간 거슬려서 수정했습니다요

## 📸 스크린샷
> 화면 캡쳐 이미지

## ✅ 체크리스트
- [x] Reviewers 태그했나요?
- [x] Label 지정했나요?
- [ ] 관련 테크스펙 링크 연결했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * "이 선생님과 할래요" 버튼의 활성화/비활성화 로직이 개선되어, 선택된 행과 선생님 상태에 따라 더 정확하게 버튼 상태가 반영됩니다.  


<!-- end of auto-generated comment: release notes by coderabbit.ai -->