### PR TITLE
[feat] 선생님 수업세션 목록 페이지 - 월별 수업진행 시간 보여주는 컴포넌트 추가

### DIFF
--- a/app/components/teacher/Session/MonthDurationNavigator.tsx
+++ b/app/components/teacher/Session/MonthDurationNavigator.tsx
@@ -1,0 +1,31 @@
+import Image from "next/image";
+
+interface MonthDurationNavigatorProps {
+  defaultMonth: number;
+  monthDuration: {
+    [key: string]: number;
+  };
+}
+
+export default function MonthDurationNavigator(
+  props: MonthDurationNavigatorProps,
+) {
+  const { defaultMonth, monthDuration } = props;
+
+  return (
+    <div className="flex h-12 w-full justify-between bg-grey-100">
+      <Image
+        src="/public/images/icon-arrow.svg"
+        alt="left-arrow"
+        width={40}
+        height={40}
+      />
+      <Image
+        src="/public/images/icon-arrow.svg"
+        alt="right-arrow"
+        width={40}
+        height={40}
+      />
+    </div>
+  );
+}

--- a/app/components/teacher/Session/MonthDurationNavigator.tsx
+++ b/app/components/teacher/Session/MonthDurationNavigator.tsx
@@ -1,4 +1,5 @@
 import Image from "next/image";
+import { useMemo, useState } from "react";
 
 interface MonthDurationNavigatorProps {
   defaultMonth: number;
@@ -12,20 +13,77 @@ export default function MonthDurationNavigator(
 ) {
   const { defaultMonth, monthDuration } = props;
 
+  // monthDuration의 키들을 숫자로 변환하고 정렬
+  const availableMonths = useMemo(() => {
+    return Object.keys(monthDuration)
+      .map(Number)
+      .sort((a, b) => a - b);
+  }, [monthDuration]);
+
+  // 디폴트 월 (defaultMonth 있으면 사용하고, 없으면 그냥 가장 최근 월)
+  const [currentMonth, setCurrentMonth] = useState(() => {
+    if (availableMonths.includes(defaultMonth)) {
+      return defaultMonth;
+    }
+    const maxMonth = Math.max(...availableMonths);
+    return maxMonth;
+  });
+
+  // 현재 월의 인덱스
+  const currentIndex = availableMonths.indexOf(currentMonth);
+
+  // 이전 월로 이동
+  const goToPreviousMonth = () => {
+    if (currentIndex > 0) {
+      setCurrentMonth(availableMonths[currentIndex - 1]);
+    }
+  };
+
+  // 다음 월로 이동
+  const goToNextMonth = () => {
+    if (currentIndex < availableMonths.length - 1) {
+      setCurrentMonth(availableMonths[currentIndex + 1]);
+    }
+  };
+
+  // 화살표 활성화/비활성화 상태
+  const canGoPrevious = currentIndex > 0;
+  const canGoNext = currentIndex < availableMonths.length - 1;
+
+  // 현재 월의 데이터
+  const currentDuration = monthDuration[currentMonth.toString()] || 0;
+
   return (
-    <div className="flex h-12 w-full justify-between bg-grey-100">
-      <Image
-        src="/public/images/icon-arrow.svg"
-        alt="left-arrow"
-        width={40}
-        height={40}
-      />
-      <Image
-        src="/public/images/icon-arrow.svg"
-        alt="right-arrow"
-        width={40}
-        height={40}
-      />
+    <div className="flex h-12 w-full items-center justify-between rounded-xl bg-grey-100 px-5 py-1">
+      <button
+        onClick={goToPreviousMonth}
+        disabled={!canGoPrevious}
+        className={!canGoPrevious ? "opacity-30" : ""}
+      >
+        <Image
+          src="/images/icon_arrow.svg"
+          alt="left-arrow"
+          width={20}
+          height={20}
+        />
+      </button>
+      <div className="flex min-w-36 gap-2 text-[#475569]">
+        <p className="font-semibold">{currentMonth}월 수업진행</p>
+        <p className="font-bold">{currentDuration}분</p>
+      </div>
+      <button
+        onClick={goToNextMonth}
+        disabled={!canGoNext}
+        className={!canGoNext ? "opacity-30" : ""}
+      >
+        <Image
+          src="/images/icon_arrow.svg"
+          alt="right-arrow"
+          width={20}
+          height={20}
+          className="rotate-180"
+        />
+      </button>
     </div>
   );
 }


### PR DESCRIPTION
## 🐈 PR 요약
> PR 내용 한 줄로 요약
- 관련 테크스펙 링크 : x
- 월별 수업진행 시간 보여주는 컴포넌트 추가

## ✨ PR 상세
> PR 상세 내용 개조식으로 작성
- 선생님 수업세션 목록 페이지에서 월별 수업진행 시간 보여주는 컴포넌트 구현

## 🚨 참고사항
> 리뷰어들이 알아야 하거나 알면 좋은 참고사항 작성
- 내일 당일휴강이랑 어드민에서 최종매칭 main으로 올리기로 해서 이건 approve 받아도 바로 머지 안 하겠습니다!

## 📸 스크린샷
> 화면 캡쳐 이미지


https://github.com/user-attachments/assets/70aca551-4c3a-44ee-8443-3511276e4f64


## ✅ 체크리스트
- [x] Reviewers 태그했나요?
- [x] Label 지정했나요?
- [ ] 관련 테크스펙 링크 연결했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 강사 세션 화면에 월별 진행 내비게이터 추가.
  * 좌/우 화살표로 이용 가능한 월 사이를 이동하고, 중앙에 해당 월의 수업 진행 시간(분)을 표시.
  * 이동 한계에 도달하면 버튼이 자동 비활성화되어 실수 방지.
  * 초기 표시 월은 기본값 또는 이용 가능한 최대 월로 자동 설정.
  * 시각적 피드백(불투명도 변화)과 정돈된 아이콘/레이아웃으로 가독성과 사용성 향상.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->