### PR TITLE
[feat] 선생님 수업관리 페이지 수정사항 반영

### DIFF
--- a/app/(route)/(teacher)/teacher/session-schedule/page.tsx
+++ b/app/(route)/(teacher)/teacher/session-schedule/page.tsx
@@ -9,11 +9,20 @@ import SessionList from "@/components/teacher/SessionList";
 import { useGetSessions } from "@/hooks/query/useGetSessions";
 import TabBar from "@/ui/Bar/TabBar";
 import LoadingUI from "@/ui/LoadingUI";
+import { useGetSessionsMonth } from "@/hooks/query/useGetSessionsMonth";
+import MonthDurationNavigator from "@/components/teacher/Session/MonthDurationNavigator";
 
 export default function TeacherSessionScheduleListPage() {
   const searchParams = useSearchParams();
   const token = searchParams.get("token") ?? "";
+  const classId = searchParams.get("classId");
+
   const { data, isLoading } = useGetSessions(token, 0, 3);
+  const { data: sessionsMonthData } = useGetSessionsMonth(
+    classId
+      ? { classMatchingId: Number(classId), monthCount: 2 }
+      : { token, monthCount: 2 },
+  );
 
   if (isLoading) {
     return <LoadingUI />;
@@ -28,9 +37,17 @@ export default function TeacherSessionScheduleListPage() {
     content: <SessionList key={classId} classId={classId} />,
   }));
 
+  const currentMonth = new Date().getMonth() + 1;
+
   return (
     <ErrorBoundary fallback={<ErrorUI />}>
-      <HeaderWithBack title="과외 일정" className="border-none">
+      <HeaderWithBack title="내 과외 관리" className="border-none">
+        <div className="flex items-center px-5 py-2">
+          <MonthDurationNavigator
+            defaultMonth={currentMonth}
+            monthDuration={sessionsMonthData?.months || {}}
+          />
+        </div>
         <TabBar
           tabs={tabs}
           paramKey="classId"

--- a/app/(route)/(teacher)/teacher/session-schedule/page.tsx
+++ b/app/(route)/(teacher)/teacher/session-schedule/page.tsx
@@ -19,9 +19,11 @@ export default function TeacherSessionScheduleListPage() {
 
   const { data, isLoading } = useGetSessions(token, 0, 3);
   const { data: sessionsMonthData } = useGetSessionsMonth(
-    classId
-      ? { classMatchingId: Number(classId), monthCount: 2 }
-      : { token, monthCount: 2 },
+    token
+      ? { token, monthCount: 2 }
+      : classId
+        ? { classMatchingId: classId, monthCount: 2 }
+        : { token: "", monthCount: 2 },
   );
 
   if (isLoading) {

--- a/app/actions/get-sessions-month/index.ts
+++ b/app/actions/get-sessions-month/index.ts
@@ -8,7 +8,7 @@ export type SessionsMonthParams =
       monthCount: number;
     }
   | {
-      classMatchingId: number;
+      classMatchingId: string;
       token?: never; // classMatchingId가 있을 때는 token 금지
       monthCount: number;
     };

--- a/app/components/teacher/Session/MonthDurationNavigator.tsx
+++ b/app/components/teacher/Session/MonthDurationNavigator.tsx
@@ -67,7 +67,7 @@ export default function MonthDurationNavigator(
           height={20}
         />
       </button>
-      <div className="flex min-w-36 gap-2 text-[#475569]">
+      <div className="flex min-w-36 items-center justify-center gap-2 text-[#475569]">
         <p className="font-semibold">{currentMonth}월 수업진행</p>
         <p className="font-bold">{currentDuration}분</p>
       </div>

--- a/app/components/teacher/SessionList/index.tsx
+++ b/app/components/teacher/SessionList/index.tsx
@@ -122,6 +122,7 @@ export default function SessionList({ classId }: SessionListProps) {
               key={session.id}
               date={session.date}
               time={session.time}
+              classMinute={session.classMinute}
               statusLabel={session.statusLabel}
               actions={session.actions}
               showMoneyReminder={session.showMoneyReminder}

--- a/app/components/teacher/SessionList/index.tsx
+++ b/app/components/teacher/SessionList/index.tsx
@@ -140,7 +140,7 @@ export default function SessionList({ classId }: SessionListProps) {
             className="cursor-default bg-transparent py-3 text-[14px] font-semibold text-gray-700"
             onClick={() => setIsExpanded(true)}
           >
-            <span className="flex cursor-pointer items-center">
+            <span className="flex cursor-pointer items-center text-base">
               더보기
               <IconDown className="ml-1 size-5" IconColor="#374151" />
             </span>

--- a/app/components/teacher/SessionList/index.tsx
+++ b/app/components/teacher/SessionList/index.tsx
@@ -7,7 +7,7 @@ import Image from "next/image";
 import { useGetSessions } from "@/hooks/query/useGetSessions";
 import { SessionResponse } from "@/actions/post-getSessions";
 import SessionListCard from "@/ui/Card/SessionListCard";
-import Chip from "@/ui/Chip";
+import Select from "@/ui/Select";
 import Button from "@/ui/Button";
 import IconDown from "@/icons/IconDown";
 import LoadingUI from "@/ui/LoadingUI";
@@ -66,6 +66,18 @@ export default function SessionList({ classId }: SessionListProps) {
     setSessions([]);
   };
 
+  const handleFilterChange = (value: string) => {
+    const next = value === "completed";
+    changeFilter(next);
+  };
+
+  const filterOptions = [
+    { value: "scheduled", label: "예정된 수업" },
+    { value: "completed", label: "완료된 수업" },
+  ];
+
+  const currentFilterValue = isComplete ? "completed" : "scheduled";
+
   const isInitialLoading = sessions.length === 0 && (isLoading || isFetching);
   const hasMore = items.length > 3 && !isExpanded;
 
@@ -77,15 +89,11 @@ export default function SessionList({ classId }: SessionListProps) {
     <div className="min-h-screen space-y-3 bg-gray-50 px-5 py-4">
       <section className="mb-4 flex items-center justify-between">
         <div className="flex gap-2">
-          <Chip
-            chipText="미완료"
-            isSelected={!isComplete}
-            onClick={() => changeFilter(false)}
-          />
-          <Chip
-            chipText="완료"
-            isSelected={isComplete}
-            onClick={() => changeFilter(true)}
+          <Select
+            options={filterOptions}
+            value={currentFilterValue}
+            onChange={handleFilterChange}
+            className="w-32"
           />
         </div>
         {!isPaused && (

--- a/app/components/teacher/SessionList/useSessionList.ts
+++ b/app/components/teacher/SessionList/useSessionList.ts
@@ -25,6 +25,7 @@ export interface SessionItem {
   isTodayCancel?: boolean;
   cancelReason?: CancelReason;
   cancel?: boolean;
+  classMinute: number;
 }
 
 export function useSessionList(data: SessionResponse[]): SessionItem[] {
@@ -43,6 +44,7 @@ export function useSessionList(data: SessionResponse[]): SessionItem[] {
         maxRound,
         isTodayCancel,
         cancelReason,
+        classMinute,
       } = session;
 
       // Date 객체 생성 및 시간 포맷
@@ -106,6 +108,7 @@ export function useSessionList(data: SessionResponse[]): SessionItem[] {
         currentRound,
         maxRound,
         cancel,
+        classMinute,
       };
     });
 

--- a/app/hooks/mutation/usePatchSessions.ts
+++ b/app/hooks/mutation/usePatchSessions.ts
@@ -101,6 +101,9 @@ export function useSessionMutations() {
 
       await queryClient.refetchQueries({ queryKey: ["sessions"] });
 
+      // sessions-month 쿼리도 무효화
+      await queryClient.invalidateQueries({ queryKey: ["sessions-month"] });
+
       params.set("is-complete", "true");
       router.push(`/teacher/session-schedule?${params.toString()}`);
 

--- a/app/ui/Card/SessionListCard/index.tsx
+++ b/app/ui/Card/SessionListCard/index.tsx
@@ -189,13 +189,14 @@ export default function SessionListCard({
           <div className="flex items-center">
             {currentRound > 0 && (
               <Badge className={cn(isToggle && "mr-2")}>
-                {maxRound ?? "-"}회 중{" "}
-                <strong className="ml-1 font-semibold">
-                  {currentRound ?? "-"}회
+                <strong className="font-semibold">
+                  {currentRound ?? "-"}회차
                 </strong>
               </Badge>
             )}
-            {currentRound === 0 && <Badge>무료보강</Badge>}
+            {currentRound === 0 && (
+              <Badge className="font-semibold text-primary">무료보강</Badge>
+            )}
             <IconDown
               className={cn({
                 hidden: !isToggle,

--- a/app/ui/Card/SessionListCard/index.tsx
+++ b/app/ui/Card/SessionListCard/index.tsx
@@ -32,6 +32,7 @@ export interface SessionListCardProps {
   classSessionId: number;
   date: Date;
   time: string;
+  classMinute: number;
   statusLabel: string;
   actions: ActionButton[];
   showMoneyReminder?: boolean;
@@ -46,6 +47,7 @@ export default function SessionListCard({
   classSessionId,
   date,
   time,
+  classMinute,
   statusLabel,
   actions,
   showMoneyReminder,
@@ -172,11 +174,12 @@ export default function SessionListCard({
               </span>
             )}
             <span className="text-[16px] font-[600] text-gray-900">
-              {`${date.getMonth() + 1}.${date.getDate()} ${date.toLocaleDateString(
+              {`${date.getMonth() + 1}.${date.getDate()} (${date.toLocaleDateString(
                 "ko-KR",
-                { weekday: "long" },
-              )} ${time}`}
+                { weekday: "short" },
+              )}) ${time}`}
             </span>
+            <span className="ml-[6px] text-gray-500">{`${classMinute}분 수업`}</span>
           </div>
           {(statusLabel === "선생님 당일휴강" ||
             statusLabel === "학부모 당일휴강") && (

--- a/app/ui/Select/index.tsx
+++ b/app/ui/Select/index.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { useState, useRef, useEffect } from "react";
+
+import IconDown from "@/icons/IconDown";
+
+interface SelectOption {
+  value: string;
+  label: string;
+}
+
+interface SelectProps {
+  options: SelectOption[];
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+  className?: string;
+}
+
+export default function Select({
+  options,
+  value,
+  onChange,
+  placeholder = "선택하세요",
+  className = "",
+}: SelectProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const selectRef = useRef<HTMLDivElement>(null);
+
+  const selectedOption = options.find((option) => option.value === value);
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        selectRef.current &&
+        !selectRef.current.contains(event.target as Node)
+      ) {
+        setIsOpen(false);
+      }
+    };
+
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  const handleSelect = (optionValue: string) => {
+    onChange(optionValue);
+    setIsOpen(false);
+  };
+
+  return (
+    <div className={`relative ${className}`} ref={selectRef}>
+      <button
+        type="button"
+        className="flex w-full items-center justify-between rounded-lg border border-gray-300 bg-white px-3 py-2 text-left text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+        onClick={() => setIsOpen(!isOpen)}
+      >
+        <span className={selectedOption ? "text-gray-900" : "text-gray-500"}>
+          {selectedOption ? selectedOption.label : placeholder}
+        </span>
+        <IconDown
+          className={`ml-2 size-4 transition-transform ${
+            isOpen ? "rotate-180" : ""
+          }`}
+          IconColor="#6B7280"
+        />
+      </button>
+
+      {isOpen && (
+        <div className="absolute z-10 mt-1 w-full rounded-md border border-gray-300 bg-white shadow-lg">
+          <ul className="max-h-60 overflow-auto py-1">
+            {options.map((option) => (
+              <li key={option.value}>
+                <button
+                  type="button"
+                  className={`block w-full px-3 py-2 text-left text-sm hover:bg-gray-100 ${
+                    option.value === value
+                      ? "bg-blue-50 text-blue-700"
+                      : "text-gray-900"
+                  }`}
+                  onClick={() => handleSelect(option.value)}
+                >
+                  {option.label}
+                </button>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/ui/index.ts
+++ b/app/ui/index.ts
@@ -6,3 +6,4 @@ export * from "./TitleDesc";
 export * from "./Header";
 export * from "./Modal/Modal";
 export * from "./Pagination";
+export { default as Select } from "./Select";


### PR DESCRIPTION
## 🐈 PR 요약
> PR 내용 한 줄로 요약
- 관련 테크스펙 링크 : x
- 선생님 `session-schedule` 페이지 수정

## ✨ PR 상세
> PR 상세 내용 개조식으로 작성
- 타이틀 변경: `과외 일정` -> `내 과외 관리`
- 더보기 버튼 살짝 키움 (모바일에서 잘 안 보인다는 의견이 있어서)
- 무료보강 뱃지 강조 (컬러 변경)
- `MonthDurationNavigator` 중앙 정렬 잘 안 되는 문제 있어서 수정
- 월별 진행시간 보여주는 컴포넌트에 api 연결
- 과외 완료하면 월별 진행시간 쿼리 무효화
- `maxRound`제외 (`maxRound회 중 currentRound회` -> `currentRound회차`로 변경)
- `미완료`/`완료` Chip -> `예정된 수업`/`완료된 수업` DropDown Select로 변경 (선택하면 컨텐츠 바뀜)
- 수업 `SessionCard`에 `classMinute` 추가 (ex. 50분 수업)

## 🚨 참고사항
> 리뷰어들이 알아야 하거나 알면 좋은 참고사항 작성
- `token` 말고 `classMatchingId` 있을 때 제대로 동작하지 않아서 수정 예정
- 일단 PR부터 올려둡니다

## 📸 스크린샷
> 화면 캡쳐 이미지

<img width="416" height="716" alt="image" src="https://github.com/user-attachments/assets/ad0cca0b-a271-42a6-8ef5-ae274ef0bf50" />


## ✅ 체크리스트
- [x] Reviewers 태그했나요?
- [x] Label 지정했나요?
- [ ] 관련 테크스펙 링크 연결했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 월별 세션 탐색기 추가(현재 달 기본, 최대 2개월 범위).
  - 세션 목록 필터를 드롭다운으로 전환.
  - 세션 카드에 수업 시간(분) 표시 및 날짜/요일 표기 개선.
- Bug Fixes
  - 세션 완료 처리 후 월별 일정이 즉시 갱신되도록 개선.
- Style
  - 월 범위 표시 영역 가운데 정렬.
  - 헤더 제목을 “내 과외 관리”로 변경.
  - 배지 문구/스타일 다듬기(“회차” 표기, “무료보강” 강조).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->