### PR TITLE
fix: 무료보강일 때는 휴강 버튼 제거

### DIFF
--- a/app/components/teacher/SessionList/useSessionList.ts
+++ b/app/components/teacher/SessionList/useSessionList.ts
@@ -62,12 +62,16 @@ export function useSessionList(data: SessionResponse[]): SessionItem[] {
       const isToday = classDay.getTime() === today.getTime();
       const isTodayOrPast = classDay.getTime() <= today.getTime();
       const isFuture = classDay.getTime() > today.getTime();
+      const isFreeSupplement = !cancel && currentRound === 0;
       const showMoneyReminder = isTodayOrPast && !complete && !cancel;
 
       let statusLabel = "";
       let actions: ActionButton[] = [];
 
       switch (true) {
+        case isFreeSupplement:
+          actions = [BTN_RESCHEDULE, BTN_COMPLETE];
+          break;
         case isTodayCancel && cancelReason === "TEACHER":
           statusLabel = CANCEL_TEXT.SAME_DAY_CANCEL_BY_TEACHER_SHORT;
           break;


### PR DESCRIPTION
## 🐈 PR 요약
> PR 내용 한 줄로 요약
- 관련 테크스펙 링크 : -

## ✨ PR 상세
> PR 상세 내용 개조식으로 작성

- 무료보강은 휴강이 불가하도록 카드에서 '휴강'버튼 제거

## 🚨 참고사항
> 리뷰어들이 알아야 하거나 알면 좋은 참고사항 작성

## 📸 스크린샷
> 화면 캡쳐 이미지

## ✅ 체크리스트
- [x] Reviewers 태그했나요?
- [x] Label 지정했나요?
- [ ] 관련 테크스펙 링크 연결했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 새 기능
  * 교사 세션 목록에서 취소되지 않았고 현재 라운드가 0인 세션에 [예약 변경]과 [완료] 버튼이 새로 제공됩니다. 초기 세션을 더 빠르게 처리할 수 있으며, 기타 세션 유형은 기존과 동일한 버튼 구성이 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->