### PR TITLE
fix: classMinute null이면 안 보이게 처리

### DIFF
--- a/app/ui/Card/SessionListCard/index.tsx
+++ b/app/ui/Card/SessionListCard/index.tsx
@@ -179,7 +179,9 @@ export default function SessionListCard({
                 { weekday: "short" },
               )}) ${time}`}
             </span>
-            <span className="ml-[6px] text-gray-500">{`${classMinute}분 수업`}</span>
+            {classMinute && classMinute > 0 && (
+              <span className="ml-[6px] text-gray-500">{`${classMinute}분 수업`}</span>
+            )}
           </div>
           {(statusLabel === "선생님 당일휴강" ||
             statusLabel === "학부모 당일휴강") && (


### PR DESCRIPTION
## 🐈 PR 요약
> PR 내용 한 줄로 요약
- 관련 테크스펙 링크 : x
- `classMinute` null이면 안 보이게 처리

## ✨ PR 상세
> PR 상세 내용 개조식으로 작성

## 🚨 참고사항
> 리뷰어들이 알아야 하거나 알면 좋은 참고사항 작성

## 📸 스크린샷
> 화면 캡쳐 이미지

## ✅ 체크리스트
- [ ] Reviewers 태그했나요?
- [ ] Label 지정했나요?
- [ ] 관련 테크스펙 링크 연결했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 해당 없음
- 버그 수정
  - 세션 카드에서 수업 시간 라벨이 실제 값이 있을 때(>0)만 표시되도록 수정했습니다. 이전에는 0분 또는 값이 없을 때도 “X분 수업”이 노출되어 혼란을 줄 수 있었습니다. 이제 유효한 시간일 때만 표시되어 정보의 정확성과 화면 가독성이 개선되었습니다.
- 문서
  - 해당 없음
- 기타
  - 공개 API 변경 없음

<!-- end of auto-generated comment: release notes by coderabbit.ai -->