### PR TITLE
fix: 학부모 당일휴강 회차 정보 나오게 수정 + 완료 수업에서 무료보강 '작성한 리뷰보기'로 안 보이는 버그 수정

### DIFF
--- a/app/components/teacher/SessionList/useSessionList.ts
+++ b/app/components/teacher/SessionList/useSessionList.ts
@@ -62,12 +62,16 @@ export function useSessionList(data: SessionResponse[]): SessionItem[] {
       const isToday = classDay.getTime() === today.getTime();
       const isTodayOrPast = classDay.getTime() <= today.getTime();
       const isFuture = classDay.getTime() > today.getTime();
+      const isFreeSupplement = !cancel && currentRound === 0 && !complete;
       const showMoneyReminder = isTodayOrPast && !complete && !cancel;
 
       let statusLabel = "";
       let actions: ActionButton[] = [];
 
       switch (true) {
+        case isFreeSupplement:
+          actions = [BTN_RESCHEDULE, BTN_COMPLETE];
+          break;
         case isTodayCancel && cancelReason === "TEACHER":
           statusLabel = CANCEL_TEXT.SAME_DAY_CANCEL_BY_TEACHER_SHORT;
           break;

--- a/app/ui/Card/SessionListCard/index.tsx
+++ b/app/ui/Card/SessionListCard/index.tsx
@@ -123,10 +123,7 @@ export default function SessionListCard({
   // Badge 표시 조건을 명확하게 분리
   const shouldShowBadge = (() => {
     // 당일휴강 상태면 Badge 안 보임
-    if (
-      statusLabel === "선생님 당일휴강" ||
-      statusLabel === "학부모 당일휴강"
-    ) {
+    if (statusLabel === "선생님 당일휴강") {
       return false;
     }
 


### PR DESCRIPTION
## 🐈 PR 요약
> PR 내용 한 줄로 요약
- 관련 테크스펙 링크 : x
- QA 올라온 문제 2개 수정했습니다!

## ✨ PR 상세
> PR 상세 내용 개조식으로 작성
- 학부모 당일휴강에서 '회차' 정보 나오게 수정
- 무료보강 완료로 넘어갔을 때, '작성한 리뷰보기' 버튼이 안 나오는 문제 수정했습니다

## 🚨 참고사항
> 리뷰어들이 알아야 하거나 알면 좋은 참고사항 작성

## 📸 스크린샷
> 화면 캡쳐 이미지

## ✅ 체크리스트
- [x] Reviewers 태그했나요?
- [x] Label 지정했나요?
- [x] 관련 테크스펙 링크 연결했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 새로운 기능
  - 세션 목록에서 무료 보충 회차일 때 일정 변경과 완료 버튼이 노출되며, 이 상태가 다른 케이스보다 우선 적용됩니다.
- 버그 수정
  - 학부모 당일휴강에도 뱃지가 표시되도록 수정했습니다. 이제 교사 당일휴강에서만 뱃지가 숨겨집니다.
  - 기존 케이스와 출력 구조는 유지되며, 다른 동작은 변경되지 않았습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->