### PR TITLE
fix: 과목+수업코드 합치기 & 선생님 닉네임 위치 변경 & 수업시수 삭제

### DIFF
--- a/app/ui/Columns/ClassColumns.tsx
+++ b/app/ui/Columns/ClassColumns.tsx
@@ -18,34 +18,6 @@ const statusColors = {
   일시중단: "bg-yellow-100 text-yellow-800",
 } as const;
 
-const dayMap: Record<string, string> = {
-  MON: "월",
-  TUE: "화",
-  WED: "수",
-  THU: "목",
-  FRI: "금",
-  SAT: "토",
-  SUN: "일",
-};
-
-function DayTimeCell({
-  scheduleList,
-}: {
-  scheduleList: Class["classManagement"]["schedule"];
-}) {
-  if (!scheduleList?.length) return "-";
-
-  return (
-    <div>
-      {scheduleList.map((item) => (
-        <div key={item.classScheduleId}>
-          {dayMap[item.day] || item.day} {item.start}
-        </div>
-      ))}
-    </div>
-  );
-}
-
 // 과외 상태 칩
 function StatusCell({
   status,
@@ -205,8 +177,17 @@ export function getClassColumns(
         );
       },
     }),
-    columnHelper.accessor("applicationFormId", {
+    columnHelper.display({
+      id: "applicationSubject",
       header: "수업코드",
+      cell: (props) => {
+        const subject = props.row.original.subject;
+        const applicationFormId = props.row.original.applicationFormId;
+        return `[${subject}] ${applicationFormId}`;
+      },
+    }),
+    columnHelper.accessor("teacher.nickName", {
+      header: "선생님 닉네임",
       cell: (props) => props.getValue(),
     }),
     columnHelper.accessor("parent.kakaoName", {
@@ -228,23 +209,6 @@ export function getClassColumns(
           </div>
         );
       },
-    }),
-    columnHelper.display({
-      id: "dayTime",
-      header: "정규일정",
-      cell: (props) => (
-        <DayTimeCell
-          scheduleList={props.row.original.classManagement.schedule}
-        />
-      ),
-    }),
-    columnHelper.accessor("subject", {
-      header: "과목",
-      cell: (props) => props.getValue(),
-    }),
-    columnHelper.accessor("teacher.nickName", {
-      header: "선생님 닉네임",
-      cell: (props) => props.getValue(),
     }),
     columnHelper.accessor("parent.phoneNumber", {
       header: "학부모 전화번호",


### PR DESCRIPTION
## 🐈 PR 요약
> PR 내용 한 줄로 요약
- 관련 테크스펙 링크 : x
- 결제선생 관련 어드민 수업관리 탭 UI 변경

## ✨ PR 상세
> PR 상세 내용 개조식으로 작성
- `과목`, `수업코드` 한 컬럼으로 합치기
- `수업시수` 삭제
- `선생님 닉네임` 위치 변경

## 🚨 참고사항
> 리뷰어들이 알아야 하거나 알면 좋은 참고사항 작성

## 📸 스크린샷
> 화면 캡쳐 이미지
<img width="1304" height="427" alt="image" src="https://github.com/user-attachments/assets/16720513-1a75-4b55-976c-5a796cb2a451" />


## ✅ 체크리스트
- [x] Reviewers 태그했나요?
- [x] Label 지정했나요?
- [ ] 관련 테크스펙 링크 연결했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - 수업 목록 테이블 컬럼 재구성: ‘정규일정’(요일별 상세) 열 제거.
  - ‘수업코드’ 열을 ‘과목 + 신청서 ID’ 통합 표기로 변경해 한 칸에서 주요 정보를 확인 가능.
  - ‘과목’ 열 제거로 중복 정보 축소.
  - 기존 ‘선생님 닉네임’, ‘학부모 전화번호’ 및 기타 일정/상태 관련 열은 그대로 유지.
- Style
  - 셀 내용 표기 간소화로 가독성과 스캔 속도 향상.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->