### PR TITLE
fix: 주 n회 a분으로 수업 시수 변경 (graphql 필드 변경)

### DIFF
--- a/app/actions/graphql/class-management.ts
+++ b/app/actions/graphql/class-management.ts
@@ -21,6 +21,7 @@ export const GET_CLASSLIST = gql`
       matchingId
       subject
       matchingStatus
+      classTime
       payPendingSessionCount
       maxRound
       totalClassTime
@@ -42,6 +43,7 @@ export const GET_CLASS_DETAIL = gql`
       matchingIds: $matchingIds
       matchingStatus: $matchingStatus
     ) {
+      classTime
       classManagement {
         schedule {
           classScheduleId

--- a/app/hooks/query/useGetClassList.ts
+++ b/app/hooks/query/useGetClassList.ts
@@ -28,6 +28,7 @@ export interface Class {
       classMinute: number;
     }[];
   };
+  classTime: number;
   parent: {
     kakaoName: string;
     phoneNumber: string;
@@ -43,6 +44,7 @@ export interface GetClassListResponse {
 }
 
 export interface ClassDetail {
+  classTime: number;
   classManagement: {
     firstDay: string;
     schedule: {

--- a/app/ui/Columns/ClassColumns.tsx
+++ b/app/ui/Columns/ClassColumns.tsx
@@ -199,14 +199,13 @@ export function getClassColumns(
       id: "schedule",
       header: "수업시수",
       cell: (props) => {
+        const classTime = props.row.original.classTime;
+        if (!classTime) return "-";
+
         const scheduleList = props.row.original.classManagement.schedule;
-
-        if (!scheduleList?.length) return "-";
-
         return (
           <div className="flex flex-col gap-1">
-            주 {scheduleList.length}회{" "}
-            {scheduleList.reduce((acc, item) => acc + item.classMinute, 0)}분
+            주 {scheduleList?.length ?? 0}회 {classTime}
           </div>
         );
       },


### PR DESCRIPTION
## 🐈 PR 요약
> PR 내용 한 줄로 요약
- 관련 테크스펙 링크 : -

## ✨ PR 상세
> PR 상세 내용 개조식으로 작성

- 주 1회 300분 이런식으로 주 총합 분수로 나오던 것을 1회 분수로 나오도록 graphql 필드 변경.

## 🚨 참고사항
> 리뷰어들이 알아야 하거나 알면 좋은 참고사항 작성

- graphql 필드를 classMinute > classTime으로 변경했습니다.
- classTime 은 schedule 밖에 있어서 컬럼 부분 코드도 수정했습니다.

## 📸 스크린샷
> 화면 캡쳐 이미
<img width="1254" height="135" alt="스크린샷 2025-08-30 오후 11 13 54" src="https://github.com/user-attachments/assets/70b273bf-5d08-4b4f-baf8-8fb5d60e1658" />
지

## ✅ 체크리스트
- [x] Reviewers 태그했나요?
- [x] Label 지정했나요?
- [ ] 관련 테크스펙 링크 연결했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 수업 목록/상세 조회에 수업시간(classTime) 필드가 추가되어 화면에서 해당 시간이 노출됩니다.
* 리팩터링
  * 클래스 목록의 “수업시수” 컬럼이 기존 분 합산 방식 대신 classTime 값을 직접 사용해 “주 N회 X” 형식으로 표시합니다.
  * classTime 값이 없을 경우 “-”로 표시해 빈 값에 대한 처리를 명확히 했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->