### PR TITLE
Fix: 월별 구분선 추가, 선생님 당일휴강, 휴강, 무료보강에서 수업 분수 삭제, 텍스트 수정, 카드 세부 디자인 수정 등 

### DIFF
--- a/app/components/teacher/SessionList/index.tsx
+++ b/app/components/teacher/SessionList/index.tsx
@@ -116,26 +116,44 @@ export default function SessionList({ classId }: SessionListProps) {
         <div className="text-center text-gray-500">조회된 일정이 없습니다.</div>
       ) : (
         <>
-          {(isExpanded ? items : items.slice(0, 3)).map((session, idx) => (
-            <SessionListCard
-              classSessionId={session.id}
-              key={session.id}
-              date={session.date}
-              time={session.time}
-              classMinute={session.classMinute}
-              statusLabel={session.statusLabel}
-              actions={session.actions}
-              showMoneyReminder={session.showMoneyReminder}
-              initialOpen={idx < 3}
-              currentRound={session.currentRound}
-              maxRound={session.maxRound}
-              cancel={session.cancel}
-            />
-          ))}
+          {(isExpanded ? items : items.slice(0, 3)).map((session, idx) => {
+            const currentMonth = session.date.getMonth();
+            const prevMonth =
+              idx > 0
+                ? (isExpanded ? items : items.slice(0, 3))[
+                    idx - 1
+                  ].date.getMonth()
+                : null;
+
+            const showDivider = idx > 0 && currentMonth !== prevMonth;
+
+            return (
+              <div key={session.id}>
+                {showDivider && (
+                  <div className="my-5 border-t border-dashed border-gray-300" />
+                )}
+                <SessionListCard
+                  classSessionId={session.id}
+                  date={session.date}
+                  time={session.time}
+                  classMinute={session.classMinute}
+                  statusLabel={session.statusLabel}
+                  actions={session.actions}
+                  showMoneyReminder={session.showMoneyReminder}
+                  initialOpen={idx < 3}
+                  currentRound={session.currentRound}
+                  maxRound={session.maxRound}
+                  cancel={session.cancel}
+                />
+              </div>
+            );
+          })}
 
           {!isComplete && isPaused && (
             <div className="flex justify-center p-5 text-center text-sm leading-[21px] text-grey-400">
-              {`${lastCurrentRound}회차까지 완료 후 수업이 일시정지됐어요.`}
+              {lastCurrentRound
+                ? `${lastCurrentRound}회차까지 완료 후 수업이 일시정지됐어요.`
+                : "수업이 일시정지됐어요."}
               <br />
               수업 재개는 Y-Edu에 문의해 주세요.
             </div>

--- a/app/ui/Card/SessionListCard/index.tsx
+++ b/app/ui/Card/SessionListCard/index.tsx
@@ -153,7 +153,7 @@ export default function SessionListCard({
     >
       <div
         className={cn(
-          "flex items-center justify-between",
+          "flex items-start justify-between",
           isOpen ? "mb-1" : "mb-0",
         )}
       >
@@ -176,9 +176,13 @@ export default function SessionListCard({
                 { weekday: "short" },
               )}) ${time}`}
             </span>
-            {classMinute && classMinute > 0 && (
-              <span className="ml-[6px] text-gray-500">{`${classMinute}분 수업`}</span>
-            )}
+            {classMinute &&
+              classMinute > 0 &&
+              statusLabel !== "선생님 당일휴강" &&
+              statusLabel !== "휴강" &&
+              currentRound !== 0 && ( // 무료보강
+                <span className="ml-[6px] text-gray-500">{`${classMinute}분`}</span>
+              )}
           </div>
           {(statusLabel === "선생님 당일휴강" ||
             statusLabel === "학부모 당일휴강") && (
@@ -224,7 +228,7 @@ export default function SessionListCard({
                 handleActionClick(btn.value);
               }}
               className={cn(
-                { "mt-3": isOpen },
+                { "mt-3": isOpen || defaultOpen },
                 "h-11 flex-1 whitespace-normal px-0 text-[16px] font-[700]",
                 "max-[355px]:text-sm",
                 btn.variant === "primary"


### PR DESCRIPTION
## 🐈 PR 요약
> PR 내용 한 줄로 요약
- 관련 테크스펙 링크 : -

## ✨ PR 상세
> PR 상세 내용 개조식으로 작성

- 월별 구분선 추가
- 수업 일시정지 시 수업 완료처리된게 없어 null 일 때 표시 문구 처리 추가
- 선생님 당일휴강, 휴강, 무료보강에서 수업 분수 삭제
- '수업' 텍스트 삭제
- 상단 3개의 defaultOpen 카드일때 버튼과 마진 조정
- 학부모 당일휴강 텍스트가 생긴 카드일 때 뱃지가 중앙정렬 된느 부분 > 상단정렬로 수정.

## 🚨 참고사항
> 리뷰어들이 알아야 하거나 알면 좋은 참고사항 작성

## 📸 스크린샷
> 화면 캡쳐 이미지

<img width="330" height="447" alt="스크린샷 2025-08-31 오후 10 07 49" src="https://github.com/user-attachments/assets/f2161c76-62fd-483d-bdf5-561c72b07124" />

<img width="317" height="308" alt="스크린샷 2025-08-31 오후 10 08 01" src="https://github.com/user-attachments/assets/eed0136f-0792-4ac3-ad05-9b671347bfb5" />

## ✅ 체크리스트
- [x] Reviewers 태그했나요?
- [x] Label 지정했나요?
- [ ] 관련 테크스펙 링크 연결했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * 세션 목록에서 월이 바뀌는 지점에 점선 구분선이 자동으로 표시됩니다.
* Style
  * 세션 카드 헤더가 상단 정렬로 변경되어 가독성이 개선되었습니다.
  * 분 배지 문구를 “{분}분”으로 단순화하고, 특정 휴강 상태·무료보강 시에는 숨깁니다.
  * 접힘/펼침 상태에 따라 액션 버튼 상단 여백이 일관되게 적용됩니다.
* Bug Fixes
  * 일시중지 상태에서 회차 정보가 없을 때 일반 메시지를 표시하도록 수정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->