### PR TITLE
[cherry pick] feat: 학부모 선생님 교체 / 과외 일시정지 기능

### DIFF
--- a/app/(route)/(parents)/layout.tsx
+++ b/app/(route)/(parents)/layout.tsx
@@ -1,0 +1,16 @@
+import Head from "next/head";
+
+export default function ParentsLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <>
+      <Head>
+        <meta name="viewport" content="width=device-width" />
+      </Head>
+      <div className="mx-auto max-w-[420px]">{children}</div>
+    </>
+  );
+}

--- a/app/(route)/(parents)/layout.tsx
+++ b/app/(route)/(parents)/layout.tsx
@@ -1,16 +1,10 @@
-import Head from "next/head";
+import type { ReactNode } from "react";
 
-export default function ParentsLayout({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
-  return (
-    <>
-      <Head>
-        <meta name="viewport" content="width=device-width" />
-      </Head>
-      <div className="mx-auto max-w-[420px]">{children}</div>
-    </>
-  );
+export const viewport = {
+  width: "device-width",
+  initialScale: 1,
+};
+
+export default function ParentsLayout({ children }: { children: ReactNode }) {
+  return <div className="mx-auto max-w-[420px]">{children}</div>;
 }

--- a/app/(route)/(parents)/parents/session-actions/[phoneNumber]/change/page.tsx
+++ b/app/(route)/(parents)/parents/session-actions/[phoneNumber]/change/page.tsx
@@ -7,7 +7,7 @@ export default function ParentsSessionActionsChangePage() {
   return (
     <div className="flex w-full flex-col items-center">
       <HeaderWithBack
-        title="Y-edu"
+        title="Y-Edu"
         hasBack
         onBack={() => window.history.back()}
         mainClassName="pt-8 w-full px-5"

--- a/app/(route)/(parents)/parents/session-actions/[phoneNumber]/change/page.tsx
+++ b/app/(route)/(parents)/parents/session-actions/[phoneNumber]/change/page.tsx
@@ -1,15 +1,19 @@
 "use client";
 
+import { useRouter } from "next/navigation";
+
 import SessionActions from "@/components/parents/session-actions/SessionActions";
 import HeaderWithBack from "@/components/result/HeaderWithBack";
 
 export default function ParentsSessionActionsChangePage() {
+  const router = useRouter();
+
   return (
     <div className="flex w-full flex-col items-center">
       <HeaderWithBack
         title="Y-Edu"
         hasBack
-        onBack={() => window.history.back()}
+        onBack={() => router.back()}
         mainClassName="pt-8 w-full px-5"
       >
         <SessionActions />

--- a/app/(route)/(parents)/parents/session-actions/[phoneNumber]/change/page.tsx
+++ b/app/(route)/(parents)/parents/session-actions/[phoneNumber]/change/page.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import SessionActions from "@/components/parents/session-actions/SessionActions";
+import HeaderWithBack from "@/components/result/HeaderWithBack";
+
+export default function ParentsSessionActionsChangePage() {
+  return (
+    <div className="flex w-full flex-col items-center">
+      <HeaderWithBack
+        title="Y-edu"
+        hasBack
+        onBack={() => window.history.back()}
+        mainClassName="pt-8 w-full px-5"
+      >
+        <SessionActions />
+      </HeaderWithBack>
+    </div>
+  );
+}

--- a/app/(route)/(parents)/parents/session-actions/[phoneNumber]/page.tsx
+++ b/app/(route)/(parents)/parents/session-actions/[phoneNumber]/page.tsx
@@ -1,15 +1,19 @@
 "use client";
 
+import { useRouter } from "next/navigation";
+
 import HeaderWithBack from "@/components/result/HeaderWithBack";
 import SessionActionsMain from "@/components/parents/session-actions/SessionActionsMain";
 
 export default function ParentsSessionActionsMainPage() {
+  const router = useRouter();
+
   return (
     <div className="flex w-full flex-col items-center">
       <HeaderWithBack
         title="Y-Edu"
         hasBack
-        onBack={() => window.history.back()}
+        onBack={() => router.back()}
         mainClassName="pt-8 w-full px-5"
       >
         <SessionActionsMain />

--- a/app/(route)/(parents)/parents/session-actions/[phoneNumber]/page.tsx
+++ b/app/(route)/(parents)/parents/session-actions/[phoneNumber]/page.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import HeaderWithBack from "@/components/result/HeaderWithBack";
+import SessionActionsMain from "@/components/parents/session-actions/SessionActionsMain";
+
+export default function ParentsSessionActionsMainPage() {
+  return (
+    <div className="flex w-full flex-col items-center">
+      <HeaderWithBack
+        title="Y-edu"
+        hasBack
+        onBack={() => window.history.back()}
+        mainClassName="pt-8 w-full px-5"
+      >
+        <SessionActionsMain />
+      </HeaderWithBack>
+    </div>
+  );
+}

--- a/app/(route)/(parents)/parents/session-actions/[phoneNumber]/page.tsx
+++ b/app/(route)/(parents)/parents/session-actions/[phoneNumber]/page.tsx
@@ -7,7 +7,7 @@ export default function ParentsSessionActionsMainPage() {
   return (
     <div className="flex w-full flex-col items-center">
       <HeaderWithBack
-        title="Y-edu"
+        title="Y-Edu"
         hasBack
         onBack={() => window.history.back()}
         mainClassName="pt-8 w-full px-5"

--- a/app/(route)/(parents)/parents/session-actions/[phoneNumber]/pause/page.tsx
+++ b/app/(route)/(parents)/parents/session-actions/[phoneNumber]/pause/page.tsx
@@ -1,15 +1,19 @@
 "use client";
 
+import { useRouter } from "next/navigation";
+
 import SessionActions from "@/components/parents/session-actions/SessionActions";
 import HeaderWithBack from "@/components/result/HeaderWithBack";
 
 export default function ParentsSessionActionsPausePage() {
+  const router = useRouter();
+
   return (
     <div className="flex w-full flex-col items-center">
       <HeaderWithBack
         title="Y-Edu"
         hasBack
-        onBack={() => window.history.back()}
+        onBack={() => router.back()}
         mainClassName="pt-8 w-full px-5"
       >
         <SessionActions />

--- a/app/(route)/(parents)/parents/session-actions/[phoneNumber]/pause/page.tsx
+++ b/app/(route)/(parents)/parents/session-actions/[phoneNumber]/pause/page.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import SessionActions from "@/components/parents/session-actions/SessionActions";
+import HeaderWithBack from "@/components/result/HeaderWithBack";
+
+export default function ParentsSessionActionsPausePage() {
+  return (
+    <div className="flex w-full flex-col items-center">
+      <HeaderWithBack
+        title="Y-edu"
+        hasBack
+        onBack={() => window.history.back()}
+        mainClassName="pt-8 w-full px-5"
+      >
+        <SessionActions />
+      </HeaderWithBack>
+    </div>
+  );
+}

--- a/app/(route)/(parents)/parents/session-actions/[phoneNumber]/pause/page.tsx
+++ b/app/(route)/(parents)/parents/session-actions/[phoneNumber]/pause/page.tsx
@@ -7,7 +7,7 @@ export default function ParentsSessionActionsPausePage() {
   return (
     <div className="flex w-full flex-col items-center">
       <HeaderWithBack
-        title="Y-edu"
+        title="Y-Edu"
         hasBack
         onBack={() => window.history.back()}
         mainClassName="pt-8 w-full px-5"

--- a/app/(route)/(parents)/parents/session-actions/[phoneNumber]/submit/page.tsx
+++ b/app/(route)/(parents)/parents/session-actions/[phoneNumber]/submit/page.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import SessionActionSubmit from "@/components/parents/session-actions/SessionActionsSubmit";
+
+export default function ParentsSessionActionsMainPage() {
+  return (
+    <div className="flex w-full flex-col items-center">
+      <SessionActionSubmit />
+    </div>
+  );
+}

--- a/app/(route)/(parents)/parents/session-actions/page.tsx
+++ b/app/(route)/(parents)/parents/session-actions/page.tsx
@@ -1,0 +1,17 @@
+import { ErrorBoundary } from "react-error-boundary";
+
+import ErrorUI from "@/ui/ErrorUI";
+import SessionActionsLogin from "@/components/parents/session-actions/SessionActionsLogin";
+import HeaderWithBack from "@/components/result/HeaderWithBack";
+
+export default function ParentsSessionActionsLoginPage() {
+  return (
+    <div className="flex flex-col items-center">
+      <ErrorBoundary fallback={<ErrorUI />}>
+        <HeaderWithBack title="Y-Edu" mainClassName="pt-8 w-full px-5">
+          <SessionActionsLogin />
+        </HeaderWithBack>
+      </ErrorBoundary>
+    </div>
+  );
+}

--- a/app/(route)/(teacher)/layout.tsx
+++ b/app/(route)/(teacher)/layout.tsx
@@ -1,16 +1,10 @@
-import Head from "next/head";
+import type { ReactNode } from "react";
 
-export default function TeacherLayout({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
-  return (
-    <>
-      <Head>
-        <meta name="viewport" content="width=device-width" />
-      </Head>
-      <div className="mx-auto max-w-[420px]">{children}</div>
-    </>
-  );
+export const viewport = {
+  width: "device-width",
+  initialScale: 1,
+};
+
+export default function TeacherLayout({ children }: { children: ReactNode }) {
+  return <div className="mx-auto max-w-[420px]">{children}</div>;
 }

--- a/app/(route)/(teachersetting)/teachersetting/layout.tsx
+++ b/app/(route)/(teachersetting)/teachersetting/layout.tsx
@@ -1,7 +1,14 @@
+import type { ReactNode } from "react";
+
+export const viewport = {
+  width: "device-width",
+  initialScale: 1,
+};
+
 export default function TeacherSettingLayout({
   children,
 }: {
-  children: React.ReactNode;
+  children: ReactNode;
 }) {
-  return <div className="mx-auto max-w-[375px]">{children}</div>;
+  return <div className="mx-auto max-w-[420px]">{children}</div>;
 }

--- a/app/actions/get-parents-sessions/index.ts
+++ b/app/actions/get-parents-sessions/index.ts
@@ -1,0 +1,22 @@
+import { httpService } from "@/utils/httpService";
+
+export interface Session {
+  sessionId: number;
+  sessionDate: string;
+  roundNumber: number;
+}
+
+export interface ParentsSessionItem {
+  applicationFormId: string;
+  teacherNickname: string;
+  sessions: Session[];
+}
+
+export type ParentsSessionsResponse = ParentsSessionItem[];
+
+export async function getParentsSessionsByPhoneNumber(phoneNumber: string) {
+  const res = await httpService.get<ParentsSessionsResponse>(
+    `/parents/${phoneNumber}/sessions`,
+  );
+  return res.data;
+}

--- a/app/actions/get-parents-sessions/index.ts
+++ b/app/actions/get-parents-sessions/index.ts
@@ -1,9 +1,17 @@
 import { httpService } from "@/utils/httpService";
 
+export type SessionActionsType = "PAUSE" | "CHANGE_TEACHER";
+
+export interface SessionSubmitState {
+  PAUSE: boolean;
+  CHANGE_TEACHER: boolean;
+}
+
 export interface Session {
   sessionId: number;
   sessionDate: string;
   roundNumber: number;
+  isSubmit?: SessionSubmitState;
 }
 
 export interface ParentsSessionItem {

--- a/app/actions/post-parents-session-actions/index.ts
+++ b/app/actions/post-parents-session-actions/index.ts
@@ -1,0 +1,22 @@
+import { httpService } from "@/utils/httpService";
+
+export type SessionActionsType = "PAUSE" | "CHANGE_TEACHER";
+
+export interface ParentsSessionActionsRequest {
+  sessionId: number;
+  type: SessionActionsType;
+}
+
+export async function postParentsSessionActions(
+  phoneNumber: string,
+  payload: ParentsSessionActionsRequest,
+): Promise<void> {
+  await httpService.post(
+    `/parents/${phoneNumber}/sessions/change-form`,
+    payload,
+    {
+      validateStatus: (status) =>
+        status === 204 || (status >= 200 && status < 300),
+    },
+  );
+}

--- a/app/components/parents/session-actions/SessionActions.tsx
+++ b/app/components/parents/session-actions/SessionActions.tsx
@@ -47,10 +47,10 @@ export default function SessionActions() {
   const [selectedSessionId, setSelectedSessionId] = useState<number | null>(
     null,
   );
-  const isButtonDisabled = !selectedSessionId;
+  const isButtonDisabled = !selectedSessionId || mutation.isPending;
 
   const handleSubmit = () => {
-    if (!selectedSessionId || !targetClass) return;
+    if (!selectedSessionId || !targetClass || mutation.isPending) return;
 
     mutation.mutate(
       { phoneNumber, sessionId: selectedSessionId, type: actionType },
@@ -121,7 +121,7 @@ export default function SessionActions() {
             disabled={isButtonDisabled}
             onClick={handleSubmit}
           >
-            완료하기
+            {mutation.isPending ? "잠시만 기다려주세요." : "완료하기"}
           </Button>
         </div>
       </div>

--- a/app/components/parents/session-actions/SessionActions.tsx
+++ b/app/components/parents/session-actions/SessionActions.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { useParams, useSearchParams, useRouter } from "next/navigation";
+import { useMemo, useState } from "react";
+
+import { useGetParentsSessionsByPhone } from "@/hooks/query/useGetParentsSessionsByPhoneNumber";
+import TitleSection from "@/ui/TitleSection";
+import Button from "@/ui/Button";
+import ParentSessionListCard from "@/ui/Card/ParentSessionListCard";
+
+export default function SessionActions() {
+  const router = useRouter();
+  const { phoneNumber } = useParams<{ phoneNumber: string }>();
+  const searchParams = useSearchParams();
+
+  const action = searchParams.get("action");
+  const appKey = searchParams.get("appKey");
+
+  const { data } = useGetParentsSessionsByPhone(phoneNumber);
+
+  const targetClass = useMemo(() => {
+    if (!data || !appKey) return null;
+    const [appId, rawIndex] = appKey.split("__");
+    const idx = Number(rawIndex ?? -1);
+    const candidates = data.filter((item) => item.applicationFormId === appId);
+    return idx >= 0 ? candidates[idx] : (candidates[0] ?? null);
+  }, [data, appKey]);
+
+  const [selectedSessionId, setSelectedSessionId] = useState<number | null>(
+    null,
+  );
+
+  const isButtonDisabled = !selectedSessionId;
+
+  const handleSubmit = () => {
+    if (!selectedSessionId) return;
+
+    const sp = new URLSearchParams({
+      action: action ?? "",
+      appKey: appKey ?? "",
+      sessionId: String(selectedSessionId),
+    });
+
+    router.push(
+      `/parents/session-actions/${phoneNumber}/review?${sp.toString()}`,
+    );
+  };
+
+  return (
+    <div className="flex w-full flex-col">
+      <div className="mb-5 flex flex-col gap-10">
+        <TitleSection>
+          <TitleSection.Title className="text-[24px]">
+            언제까지 수업을 진행할까요?
+          </TitleSection.Title>
+          <TitleSection.Description className="text-[16px]">
+            일시정지 전, 마지막 수업을 선택해주세요
+          </TitleSection.Description>
+        </TitleSection>
+
+        {/* 세션 카드 목록 */}
+        <div className="flex flex-col gap-4 pb-20">
+          {targetClass?.sessions?.map((s) => {
+            const selected = selectedSessionId === s.sessionId;
+            return (
+              <button
+                key={s.sessionId}
+                type="button"
+                onClick={() => setSelectedSessionId(s.sessionId)}
+                className="w-full text-left transition-all"
+              >
+                <ParentSessionListCard
+                  date={new Date(s.sessionDate)}
+                  roundNumber={s.roundNumber}
+                  className={
+                    selected
+                      ? "rounded-[12px] border border-primary bg-primaryTint shadow-[0_4px_24px_0_rgba(0,0,0,0.05)]"
+                      : ""
+                  }
+                />
+              </button>
+            );
+          })}
+
+          {!targetClass && (
+            <div className="text-gray-500">
+              수업 정보를 불러오지 못했습니다.
+            </div>
+          )}
+        </div>
+
+        <div className="fixed inset-x-0 bottom-0 flex justify-center bg-white p-4 shadow-lg">
+          <Button
+            className="w-[375px]"
+            disabled={isButtonDisabled}
+            onClick={handleSubmit}
+          >
+            완료하기
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/components/parents/session-actions/SessionActions.tsx
+++ b/app/components/parents/session-actions/SessionActions.tsx
@@ -32,16 +32,7 @@ export default function SessionActions() {
 
   const targetClass = useMemo(() => {
     if (!data || !appKey) return null;
-
-    // appKey를 "applicationFormId_index"로 분리
-    const [appId, rawIndex] = appKey.split("__");
-    const idx = Number(rawIndex ?? -1);
-
-    // applicationFormId가 같은 항목만 필터링
-    const candidates = data.filter((item) => item.applicationFormId === appId);
-
-    // 같은 applicationFormId만 필터링 후 index번째 항목 선택
-    return idx >= 0 ? candidates[idx] : (candidates[0] ?? null);
+    return data.find((item) => item.applicationFormId === appKey) ?? null;
   }, [data, appKey]);
 
   const [selectedSessionId, setSelectedSessionId] = useState<number | null>(

--- a/app/components/parents/session-actions/SessionActions.tsx
+++ b/app/components/parents/session-actions/SessionActions.tsx
@@ -1,22 +1,34 @@
 "use client";
 
-import { useParams, useSearchParams, useRouter } from "next/navigation";
+import {
+  usePathname,
+  useParams,
+  useSearchParams,
+  useRouter,
+} from "next/navigation";
 import { useMemo, useState } from "react";
 
 import { useGetParentsSessionsByPhone } from "@/hooks/query/useGetParentsSessionsByPhoneNumber";
+import { usePostParentsSessionActions } from "@/hooks/mutation/usePostParentsSessionActions";
+import type { SessionActionsType } from "@/actions/post-parents-session-actions";
 import TitleSection from "@/ui/TitleSection";
 import Button from "@/ui/Button";
 import ParentSessionListCard from "@/ui/Card/ParentSessionListCard";
 
 export default function SessionActions() {
   const router = useRouter();
+  const pathname = usePathname();
   const { phoneNumber } = useParams<{ phoneNumber: string }>();
   const searchParams = useSearchParams();
-
-  const action = searchParams.get("action");
   const appKey = searchParams.get("appKey");
 
+  const segments = pathname.split("/").filter(Boolean);
+  const actionStr = segments.at(-1) === "change" ? "change" : "pause";
+  const actionType: SessionActionsType =
+    actionStr === "pause" ? "PAUSE" : "CHANGE_TEACHER";
+
   const { data } = useGetParentsSessionsByPhone(phoneNumber);
+  const mutation = usePostParentsSessionActions();
 
   const targetClass = useMemo(() => {
     if (!data || !appKey) return null;
@@ -29,20 +41,26 @@ export default function SessionActions() {
   const [selectedSessionId, setSelectedSessionId] = useState<number | null>(
     null,
   );
-
   const isButtonDisabled = !selectedSessionId;
 
   const handleSubmit = () => {
-    if (!selectedSessionId) return;
+    if (!selectedSessionId || !targetClass) return;
 
-    const sp = new URLSearchParams({
-      action: action ?? "",
-      appKey: appKey ?? "",
-      sessionId: String(selectedSessionId),
-    });
+    mutation.mutate(
+      { phoneNumber, sessionId: selectedSessionId, type: actionType },
+      {
+        onSuccess: () => {
+          const sp = new URLSearchParams({
+            action: actionStr,
+            applicationFormId: targetClass.applicationFormId,
+            teacherNickname: targetClass.teacherNickname,
+          });
 
-    router.push(
-      `/parents/session-actions/${phoneNumber}/review?${sp.toString()}`,
+          router.push(
+            `/parents/session-actions/${phoneNumber}/submit?${sp.toString()}`,
+          );
+        },
+      },
     );
   };
 

--- a/app/components/parents/session-actions/SessionActions.tsx
+++ b/app/components/parents/session-actions/SessionActions.tsx
@@ -6,7 +6,7 @@ import {
   useSearchParams,
   useRouter,
 } from "next/navigation";
-import { useMemo, useState } from "react";
+import { useMemo, useState, useEffect } from "react";
 
 import { useGetParentsSessionsByPhone } from "@/hooks/query/useGetParentsSessionsByPhoneNumber";
 import { usePostParentsSessionActions } from "@/hooks/mutation/usePostParentsSessionActions";
@@ -39,6 +39,19 @@ export default function SessionActions() {
     null,
   );
   const isButtonDisabled = !selectedSessionId || mutation.isPending;
+
+  // 이미 신청된 회차가 있으면 기본 선택 유지
+  useEffect(() => {
+    if (!targetClass) return;
+    const preSelected = targetClass.sessions.find(
+      (s) => s.isSubmit?.[actionType] === true,
+    );
+    if (preSelected) {
+      setSelectedSessionId(preSelected.sessionId);
+    } else {
+      setSelectedSessionId(null);
+    }
+  }, [targetClass, actionType]);
 
   const handleSubmit = () => {
     if (!selectedSessionId || !targetClass || mutation.isPending) return;

--- a/app/components/parents/session-actions/SessionActions.tsx
+++ b/app/components/parents/session-actions/SessionActions.tsx
@@ -32,9 +32,15 @@ export default function SessionActions() {
 
   const targetClass = useMemo(() => {
     if (!data || !appKey) return null;
+
+    // appKey를 "applicationFormId_index"로 분리
     const [appId, rawIndex] = appKey.split("__");
     const idx = Number(rawIndex ?? -1);
+
+    // applicationFormId가 같은 항목만 필터링
     const candidates = data.filter((item) => item.applicationFormId === appId);
+
+    // 같은 applicationFormId만 필터링 후 index번째 항목 선택
     return idx >= 0 ? candidates[idx] : (candidates[0] ?? null);
   }, [data, appKey]);
 

--- a/app/components/parents/session-actions/SessionActions.tsx
+++ b/app/components/parents/session-actions/SessionActions.tsx
@@ -72,7 +72,9 @@ export default function SessionActions() {
             언제까지 수업을 진행할까요?
           </TitleSection.Title>
           <TitleSection.Description className="text-[16px]">
-            일시정지 전, 마지막 수업을 선택해주세요
+            {actionStr === "pause"
+              ? "일시정지 전, 마지막 수업을 선택해주세요"
+              : "교체 전, 마지막 수업을 선택해주세요"}
           </TitleSection.Description>
         </TitleSection>
 

--- a/app/components/parents/session-actions/SessionActionsLogin.tsx
+++ b/app/components/parents/session-actions/SessionActionsLogin.tsx
@@ -4,7 +4,6 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 
 import { getParentsSessionsByPhoneNumber } from "@/actions/get-parents-sessions";
-import DivWithLabel from "@/components/result/DivWithLabel";
 import TitleSection from "@/ui/TitleSection";
 import Input from "@/ui/Input";
 import Button from "@/ui/Button";
@@ -41,24 +40,18 @@ export default function SessionActionsLogin() {
             입력해 주세요
           </TitleSection.Title>
         </TitleSection>
-        <DivWithLabel
-          label="수업을 진행했나요?"
-          labelClassName="text-[20px]"
-          className="w-full"
-        >
-          <Input
-            value={phoneNumber}
-            onChange={setPhoneNumber}
-            placeholder="전화번호를 입력해주세요"
-            errorMessage={
-              isSubmitted && !phoneNumber ? "전화번호를 입력해주세요." : ""
-            }
-            status={isSubmitted && !phoneNumber ? "warning" : "default"}
-            onBlur={() => {
-              document.querySelector<HTMLElement>('[role="radio"]')?.focus();
-            }}
-          />
-        </DivWithLabel>
+        <Input
+          value={phoneNumber}
+          onChange={setPhoneNumber}
+          placeholder="전화번호를 입력해주세요"
+          errorMessage={
+            isSubmitted && !phoneNumber ? "전화번호를 입력해주세요." : ""
+          }
+          status={isSubmitted && !phoneNumber ? "warning" : "default"}
+          onBlur={() => {
+            document.querySelector<HTMLElement>('[role="radio"]')?.focus();
+          }}
+        />
         <div className="fixed inset-x-0 bottom-0 flex justify-center bg-white p-4 shadow-lg">
           <Button
             className="w-[375px]"

--- a/app/components/parents/session-actions/SessionActionsLogin.tsx
+++ b/app/components/parents/session-actions/SessionActionsLogin.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+
+import { getParentsSessionsByPhoneNumber } from "@/actions/get-parents-sessions";
+import DivWithLabel from "@/components/result/DivWithLabel";
+import TitleSection from "@/ui/TitleSection";
+import Input from "@/ui/Input";
+import Button from "@/ui/Button";
+
+export default function SessionActionsLogin() {
+  const router = useRouter();
+  const [phoneNumber, setPhoneNumber] = useState("");
+  const [isSubmitted, setIsSubmitted] = useState(false);
+
+  const cleanedPhoneNumber = phoneNumber.replace(/-/g, "");
+  const isPhoneNumberValid = /^\d{10,13}$/.test(cleanedPhoneNumber);
+
+  const handleSubmit = async () => {
+    setIsSubmitted(true);
+    if (!isPhoneNumberValid) return;
+
+    const data = await getParentsSessionsByPhoneNumber(cleanedPhoneNumber);
+
+    if (!data || data.length === 0) {
+      alert("해당 번호로 등록된 과외가 없습니다.");
+      return;
+    }
+
+    router.push(`/parents/session-actions/${cleanedPhoneNumber}`);
+  };
+
+  return (
+    <div className="flex w-full flex-col">
+      <div className="mb-5 flex flex-col gap-10">
+        <TitleSection>
+          <TitleSection.Title className="text-[24px]">
+            학부모님 전화번호를
+            <br />
+            입력해 주세요
+          </TitleSection.Title>
+        </TitleSection>
+        <DivWithLabel
+          label="수업을 진행했나요?"
+          labelClassName="text-[20px]"
+          className="w-full"
+        >
+          <Input
+            value={phoneNumber}
+            onChange={setPhoneNumber}
+            placeholder="전화번호를 입력해주세요"
+            errorMessage={
+              isSubmitted && !phoneNumber ? "전화번호를 입력해주세요." : ""
+            }
+            status={isSubmitted && !phoneNumber ? "warning" : "default"}
+            onBlur={() => {
+              document.querySelector<HTMLElement>('[role="radio"]')?.focus();
+            }}
+          />
+        </DivWithLabel>
+        <div className="fixed inset-x-0 bottom-0 flex justify-center bg-white p-4 shadow-lg">
+          <Button
+            className="w-[375px]"
+            disabled={!isPhoneNumberValid}
+            onClick={handleSubmit}
+          >
+            다음
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/components/parents/session-actions/SessionActionsLogin.tsx
+++ b/app/components/parents/session-actions/SessionActionsLogin.tsx
@@ -11,23 +11,31 @@ import Button from "@/ui/Button";
 export default function SessionActionsLogin() {
   const router = useRouter();
   const [phoneNumber, setPhoneNumber] = useState("");
-  const [isSubmitted, setIsSubmitted] = useState(false);
+  const [errorMessage, setErrorMessage] = useState("");
 
   const cleanedPhoneNumber = phoneNumber.replace(/-/g, "");
   const isPhoneNumberValid = /^\d{10,13}$/.test(cleanedPhoneNumber);
 
   const handleSubmit = async () => {
-    setIsSubmitted(true);
-    if (!isPhoneNumberValid) return;
+    setErrorMessage("");
 
-    const data = await getParentsSessionsByPhoneNumber(cleanedPhoneNumber);
-
-    if (!data || data.length === 0) {
-      alert("해당 번호로 등록된 과외가 없습니다.");
+    if (!isPhoneNumberValid) {
+      setErrorMessage("전화번호 형식이 올바르지 않습니다.");
       return;
     }
 
-    router.push(`/parents/session-actions/${cleanedPhoneNumber}`);
+    try {
+      const data = await getParentsSessionsByPhoneNumber(cleanedPhoneNumber);
+
+      if (!data || data.length === 0) {
+        setErrorMessage("해당 번호로 등록된 과외가 없습니다.");
+        return;
+      }
+
+      router.push(`/parents/session-actions/${cleanedPhoneNumber}`);
+    } catch {
+      setErrorMessage("일치하지 않는 학부모 번호입니다.");
+    }
   };
 
   return (
@@ -40,18 +48,19 @@ export default function SessionActionsLogin() {
             입력해 주세요
           </TitleSection.Title>
         </TitleSection>
+
         <Input
           value={phoneNumber}
-          onChange={setPhoneNumber}
-          placeholder="전화번호를 입력해주세요"
-          errorMessage={
-            isSubmitted && !phoneNumber ? "전화번호를 입력해주세요." : ""
-          }
-          status={isSubmitted && !phoneNumber ? "warning" : "default"}
-          onBlur={() => {
-            document.querySelector<HTMLElement>('[role="radio"]')?.focus();
+          onChange={(v) => {
+            setPhoneNumber(v);
+            if (errorMessage) setErrorMessage("");
           }}
+          placeholder="전화번호를 입력해주세요"
+          errorMessage={errorMessage}
+          status={errorMessage ? "warning" : "default"}
+          onBlur={undefined}
         />
+
         <div className="fixed inset-x-0 bottom-0 flex justify-center bg-white p-4 shadow-lg">
           <Button
             className="w-[375px]"

--- a/app/components/parents/session-actions/SessionActionsMain.tsx
+++ b/app/components/parents/session-actions/SessionActionsMain.tsx
@@ -82,9 +82,9 @@ export default function SessionActionsMain() {
               </TitleSection.Title>
             </TitleSection>
             <div>
-              {data?.map(({ applicationFormId, teacherNickname }, index) => {
+              {data?.map(({ applicationFormId, teacherNickname }) => {
                 // 수업코드가 같을 경우 대비
-                const uniqueKey = `${applicationFormId}__${index}`;
+                const uniqueKey = applicationFormId;
                 return (
                   <div key={uniqueKey} className="py-4">
                     <Radio

--- a/app/components/parents/session-actions/SessionActionsMain.tsx
+++ b/app/components/parents/session-actions/SessionActionsMain.tsx
@@ -17,7 +17,7 @@ const SESSION_ACTION_OPTIONS = [
     label: "선생님 교체",
     subLabel: "다른 선생님과 수업하고 싶어요",
   },
-];
+] as const;
 
 export default function SessionActionsMain() {
   const router = useRouter();

--- a/app/components/parents/session-actions/SessionActionsMain.tsx
+++ b/app/components/parents/session-actions/SessionActionsMain.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { useParams } from "next/navigation";
+import { useState } from "react";
+
+import { useGetParentsSessionsByPhone } from "@/hooks/query/useGetParentsSessionsByPhoneNumber";
+import TitleSection from "@/ui/TitleSection";
+import Button from "@/ui/Button";
+import Radio from "@/ui/Radio";
+
+const SESSION_ACTION_OPTIONS = [
+  {
+    label: "일시정지",
+    subLabel: "수업을 잠시 쉬고싶어요",
+  },
+  {
+    label: "선생님 교체",
+    subLabel: "다른 선생님과 수업하고 싶어요",
+  },
+];
+
+export default function SessionActionsMain() {
+  const params = useParams();
+  const phoneNumber = params?.phoneNumber as string;
+
+  const { data } = useGetParentsSessionsByPhone(phoneNumber);
+  const [selectedAction, setSelectedAction] = useState("");
+  const [selectedTeacherId, setSelectedTeacherId] = useState<string>("");
+
+  const handleSelectAction = (action: string) => {
+    setSelectedAction(action);
+  };
+
+  const isButtonDisabled = !selectedAction || !selectedTeacherId;
+
+  const handleNext = () => {
+    if (!selectedAction) return;
+
+    console.log("선택된 액션:", selectedAction);
+    if (selectedAction === "선생님 교체") {
+      console.log("선택된 선생님 applicationFormId:", selectedTeacherId);
+    }
+  };
+
+  return (
+    <div className="flex w-full flex-col">
+      <div className="mb-5 flex flex-col gap-10">
+        <TitleSection>
+          <TitleSection.Title className="text-[24px]">
+            수업 상태를 어떻게
+            <br />
+            변경하시겠어요?
+          </TitleSection.Title>
+        </TitleSection>
+
+        <div>
+          {SESSION_ACTION_OPTIONS.map(({ label, subLabel }) => (
+            <div key={label} className="py-4">
+              <Radio
+                label={label}
+                subLabel={subLabel}
+                selected={selectedAction === label}
+                onClick={() => handleSelectAction(label)}
+              />
+            </div>
+          ))}
+        </div>
+
+        {selectedAction && (
+          <>
+            <div className="h-[10px] w-full bg-gray-100" />
+            <TitleSection>
+              <TitleSection.Title className="text-[24px]">
+                어떤 수업을 변경할까요?
+              </TitleSection.Title>
+            </TitleSection>
+            <div>
+              {data?.map(({ applicationFormId, teacherNickname }, index) => {
+                // 수업코드가 같을 경우 대비
+                const uniqueKey = `${applicationFormId}__${index}`;
+                return (
+                  <div key={uniqueKey} className="py-4">
+                    <Radio
+                      label={teacherNickname}
+                      subLabel={applicationFormId}
+                      selected={selectedTeacherId === uniqueKey}
+                      onClick={() => setSelectedTeacherId(uniqueKey)}
+                    />
+                  </div>
+                );
+              })}
+            </div>
+          </>
+        )}
+        <p className="mt-6 text-[16px] font-medium leading-[24px] text-grey-500">
+          수업을 완전히 중단하고 싶으신 경우, Y-Edu 카카오톡으로 매칭 매니저에게
+          문의해 주세요.
+        </p>
+      </div>
+
+      <div className="fixed inset-x-0 bottom-0 flex justify-center bg-white p-4 shadow-lg">
+        <Button
+          className="w-[375px]"
+          disabled={isButtonDisabled}
+          onClick={handleNext}
+        >
+          다음
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/app/components/parents/session-actions/SessionActionsMain.tsx
+++ b/app/components/parents/session-actions/SessionActionsMain.tsx
@@ -99,7 +99,7 @@ export default function SessionActionsMain() {
             </div>
           </>
         )}
-        <p className="mt-6 text-[16px] font-medium leading-[24px] text-grey-500">
+        <p className="mt-6 pb-20 text-[16px] font-medium leading-[24px] text-grey-500">
           수업을 완전히 중단하고 싶으신 경우, Y-Edu 카카오톡으로 매칭 매니저에게
           문의해 주세요.
         </p>

--- a/app/components/parents/session-actions/SessionActionsMain.tsx
+++ b/app/components/parents/session-actions/SessionActionsMain.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useParams } from "next/navigation";
+import { useParams, useRouter } from "next/navigation";
 import { useState } from "react";
 
 import { useGetParentsSessionsByPhone } from "@/hooks/query/useGetParentsSessionsByPhoneNumber";
@@ -20,6 +20,7 @@ const SESSION_ACTION_OPTIONS = [
 ];
 
 export default function SessionActionsMain() {
+  const router = useRouter();
   const params = useParams();
   const phoneNumber = params?.phoneNumber as string;
 
@@ -34,12 +35,18 @@ export default function SessionActionsMain() {
   const isButtonDisabled = !selectedAction || !selectedTeacherId;
 
   const handleNext = () => {
-    if (!selectedAction) return;
+    if (!selectedAction || !selectedTeacherId) return;
 
-    console.log("선택된 액션:", selectedAction);
-    if (selectedAction === "선생님 교체") {
-      console.log("선택된 선생님 applicationFormId:", selectedTeacherId);
-    }
+    // 선택한 액션에 따라 경로 분기
+    const actionPath = selectedAction === "일시정지" ? "pause" : "change";
+
+    const sp = new URLSearchParams({
+      appKey: selectedTeacherId,
+    });
+
+    router.push(
+      `/parents/session-actions/${phoneNumber}/${actionPath}?${sp.toString()}`,
+    );
   };
 
   return (

--- a/app/components/parents/session-actions/SessionActionsSubmit.tsx
+++ b/app/components/parents/session-actions/SessionActionsSubmit.tsx
@@ -19,14 +19,13 @@ export default function SessionActionSubmit() {
   const { title, description } =
     action === "pause"
       ? {
-          title: `${applicationFormId} ${teacherNickname} 수업이<br />일시정지 되었어요`,
-          description:
-            "수업을 다시 재개하고 싶다면<br />Y-edu에 문의해 주세요.",
+          title: `${applicationFormId} ${teacherNickname} 수업이\n일시정지 되었어요`,
+          description: "수업을 다시 재개하고 싶다면\nY-edu에 문의해 주세요.",
         }
       : {
-          title: `${applicationFormId} 수업의 선생님<br />교체 신청이 접수되었어요`,
+          title: `${applicationFormId} 수업의 선생님\n교체 신청이 접수되었어요`,
           description:
-            "<span class=\"text-primary\">신규 선생님 매칭</span>을 위해<br />아래 '매칭 신청서' 작성을 꼭 부탁드려요",
+            "신규 선생님 매칭을 위해\n아래 '매칭 신청서' 작성을 꼭 부탁드려요",
         };
 
   const handleMove = () => {
@@ -38,12 +37,8 @@ export default function SessionActionSubmit() {
       <div className="flex min-h-screen flex-col items-center justify-center pb-[88px] text-center">
         <Result>
           <Result.Image kind="document" />
-          <Result.Title>
-            <span dangerouslySetInnerHTML={{ __html: title }} />
-          </Result.Title>
-          <Result.Description>
-            <span dangerouslySetInnerHTML={{ __html: description }} />
-          </Result.Description>
+          <Result.Title>{title}</Result.Title>
+          <Result.Description>{description}</Result.Description>
         </Result>
       </div>
 

--- a/app/components/parents/session-actions/SessionActionsSubmit.tsx
+++ b/app/components/parents/session-actions/SessionActionsSubmit.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { useSearchParams } from "next/navigation";
+
+import { Result } from "@/ui/Result";
+import Button from "@/ui/Button";
+
+export default function SessionActionSubmit() {
+  const searchParams = useSearchParams();
+
+  const action = searchParams.get("action");
+  const applicationFormId = decodeURIComponent(
+    searchParams.get("applicationFormId") ?? "",
+  );
+  const teacherNickname = decodeURIComponent(
+    searchParams.get("teacherNickname") ?? "",
+  );
+
+  const { title, description } =
+    action === "pause"
+      ? {
+          title: `${applicationFormId} ${teacherNickname} 수업이<br />일시정지 되었어요`,
+          description:
+            "수업을 다시 재개하고 싶다면<br />Y-edu에 문의해 주세요.",
+        }
+      : {
+          title: `${applicationFormId} 수업의 선생님<br />교체 신청이 접수되었어요`,
+          description:
+            "<span class=\"text-primary\">신규 선생님 매칭</span>을 위해<br />아래 '매칭 신청서' 작성을 꼭 부탁드려요",
+        };
+
+  const handleMove = () => {
+    window.location.href = "https://www.naver.com";
+  };
+
+  return (
+    <>
+      <div className="flex min-h-screen flex-col items-center justify-center pb-[88px] text-center">
+        <Result>
+          <Result.Image kind="document" />
+          <Result.Title>
+            <span dangerouslySetInnerHTML={{ __html: title }} />
+          </Result.Title>
+          <Result.Description>
+            <span dangerouslySetInnerHTML={{ __html: description }} />
+          </Result.Description>
+        </Result>
+      </div>
+
+      {action === "change" && (
+        <div className="fixed inset-x-0 bottom-0 flex justify-center bg-white p-4 shadow-lg">
+          <Button className="w-[375px]" onClick={handleMove}>
+            매칭 신청서 쓰러가기
+          </Button>
+        </div>
+      )}
+    </>
+  );
+}

--- a/app/components/parents/session-actions/SessionActionsSubmit.tsx
+++ b/app/components/parents/session-actions/SessionActionsSubmit.tsx
@@ -29,7 +29,7 @@ export default function SessionActionSubmit() {
         };
 
   const handleMove = () => {
-    window.location.href = "https://www.naver.com";
+    window.location.href = "https://tally.so/r/mRN4al";
   };
 
   return (

--- a/app/constants/result/resultImg.ts
+++ b/app/constants/result/resultImg.ts
@@ -1,7 +1,9 @@
 import { ImgKind } from "@/ui/Result";
 
 import Letter from "public/images/Letter.svg";
+import Document from "public/images/Document.svg";
 
 export const RESULT_IMG_MAP = {
   letter: Letter,
+  document: Document,
 } satisfies Record<ImgKind, unknown>;

--- a/app/hooks/mutation/usePostParentsSessionActions.ts
+++ b/app/hooks/mutation/usePostParentsSessionActions.ts
@@ -1,0 +1,19 @@
+// 학부모 과외 일시정지 / 선생님 교체 신청 mutation 훅
+
+import { useMutation } from "@tanstack/react-query";
+
+import {
+  postParentsSessionActions,
+  ParentsSessionActionsRequest,
+} from "@/actions/post-parents-session-actions";
+
+export function usePostParentsSessionActions() {
+  return useMutation<
+    void,
+    Error,
+    { phoneNumber: string } & ParentsSessionActionsRequest
+  >({
+    mutationFn: ({ phoneNumber, sessionId, type }) =>
+      postParentsSessionActions(phoneNumber, { sessionId, type }),
+  });
+}

--- a/app/hooks/query/useGetParentsSessionsByPhoneNumber.ts
+++ b/app/hooks/query/useGetParentsSessionsByPhoneNumber.ts
@@ -1,0 +1,16 @@
+import { useQuery } from "@tanstack/react-query";
+
+import {
+  getParentsSessionsByPhoneNumber,
+  ParentsSessionsResponse,
+} from "@/actions/get-parents-sessions";
+
+export function useGetParentsSessionsByPhone(phoneNumber: string) {
+  return useQuery<ParentsSessionsResponse>({
+    queryKey: ["sessions-by-phone", phoneNumber],
+    queryFn: () => getParentsSessionsByPhoneNumber(phoneNumber),
+    enabled: !!phoneNumber,
+    staleTime: 1000 * 60 * 5,
+    gcTime: 1000 * 60 * 10,
+  });
+}

--- a/app/ui/Badge/index.tsx
+++ b/app/ui/Badge/index.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import cn from "@/utils/cn";
+
+interface BadgeProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+export default function Badge({ children, className }: BadgeProps) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center justify-center rounded-[20px] border border-grey-200 bg-white px-2 py-[2px] text-[12px] leading-[18px] text-grey-500",
+        className,
+      )}
+    >
+      {children}
+    </span>
+  );
+}

--- a/app/ui/Card/ParentSessionListCard/index.tsx
+++ b/app/ui/Card/ParentSessionListCard/index.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import Badge from "@/ui/Badge";
+import cn from "@/utils/cn";
+
+export interface SimpleSessionCardProps {
+  date: Date;
+  roundNumber: number;
+  className?: string;
+}
+
+export default function ParentSessionListCard({
+  date,
+  roundNumber,
+  className = "",
+}: SimpleSessionCardProps) {
+  return (
+    <div
+      className={cn(
+        "rounded-[16px] bg-white p-4",
+        "shadow-[0px_4px_24px_0px_rgba(0,0,0,0.05)]",
+        className,
+      )}
+    >
+      <div className="flex items-center justify-between">
+        <span className="text-[16px] font-[600] text-gray-900">
+          {`${date.getMonth() + 1}.${date.getDate()} ${date.toLocaleDateString(
+            "ko-KR",
+            { weekday: "long" },
+          )}`}
+        </span>
+
+        <Badge className="border-0 bg-primaryTint px-2 py-[2px] font-bold leading-[18px] text-primary">
+          {roundNumber}회차
+        </Badge>
+      </div>
+    </div>
+  );
+}

--- a/app/ui/Radio/index.tsx
+++ b/app/ui/Radio/index.tsx
@@ -27,7 +27,15 @@ export default function Radio({
         <IconRoundCheck isFill={selected} />
         <span className="text-gray-700">{label}</span>
       </div>
-      {subLabel && <span className="font-bold text-gray-700">{subLabel}</span>}
+      {subLabel && (
+        <span
+          className={`font-bold ${
+            selected ? "text-gray-600" : "text-gray-400"
+          }`}
+        >
+          {subLabel}
+        </span>
+      )}
     </button>
   );
 }

--- a/app/ui/Result.tsx
+++ b/app/ui/Result.tsx
@@ -16,7 +16,11 @@ function ResultImage({ kind }: { kind: ImgKind }) {
 }
 
 function ResultTitle({ children }: { children: React.ReactNode }) {
-  return <h1 className="mt-6 text-2xl font-bold text-gray-900">{children}</h1>;
+  return (
+    <h1 className="mt-6 whitespace-pre text-2xl font-bold text-gray-900">
+      {children}
+    </h1>
+  );
 }
 
 function ResultDescription({ children }: { children: React.ReactNode }) {

--- a/app/ui/Result.tsx
+++ b/app/ui/Result.tsx
@@ -2,7 +2,7 @@ import Image from "next/image";
 
 import { RESULT_IMG_MAP } from "@/constants/result/resultImg";
 
-export type ImgKind = "letter";
+export type ImgKind = "letter" | "document";
 
 function ResultImage({ kind }: { kind: ImgKind }) {
   return (

--- a/public/images/Document.svg
+++ b/public/images/Document.svg
@@ -1,0 +1,172 @@
+<svg width="83" height="82" viewBox="0 0 83 82" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g filter="url(#filter0_ii_4736_13443)">
+<rect x="0.5" y="10.3453" width="44.725" height="63.8329" rx="4.19953" fill="#224AC4"/>
+</g>
+<mask id="mask0_4736_13443" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="12" y="0" width="69" height="82">
+<path d="M19.0821 0.0545038L52.7503 0.0545009C55.0702 0.0545007 57.3024 0.940588 58.9907 2.53162L77.6416 20.1081C79.466 21.8273 80.5003 24.2231 80.5003 26.7299L80.5003 75.1212C80.5003 78.8901 77.4449 81.9454 73.676 81.9454L19.0821 81.9454C15.3131 81.9454 12.2578 78.8901 12.2578 75.1212L12.2578 6.87875C12.2578 3.10982 15.3131 0.0545041 19.0821 0.0545038Z" fill="#4D72D3"/>
+</mask>
+<g mask="url(#mask0_4736_13443)">
+<g filter="url(#filter1_dii_4736_13443)">
+<path d="M19.0821 0.0545038L52.7503 0.0545009C55.0702 0.0545007 57.3024 0.940588 58.9907 2.53162L77.6416 20.1081C79.466 21.8273 80.5003 24.2231 80.5003 26.7299L80.5003 75.1212C80.5003 78.8901 77.4449 81.9454 73.676 81.9454L19.0821 81.9454C15.3131 81.9454 12.2578 78.8901 12.2578 75.1212L12.2578 6.87875C12.2578 3.10982 15.3131 0.0545041 19.0821 0.0545038Z" fill="#5289FF"/>
+</g>
+<g filter="url(#filter2_dii_4736_13443)">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M66.8477 20.5272L80.4962 20.5272L80.4962 0.0544339L60.0234 0.0544357L60.0234 13.7029C60.0234 17.4718 63.0788 20.5272 66.8477 20.5272Z" fill="white"/>
+</g>
+</g>
+<g filter="url(#filter3_dii_4736_13443)">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M39.1956 25.0592C40.3092 26.3955 40.1287 28.3815 38.7923 29.4951L30.4361 36.4587C29.7495 37.0308 28.8522 37.2843 27.9677 37.1561C27.0832 37.0278 26.2949 36.5298 25.7991 35.7861L23.0137 31.608C22.0488 30.1607 22.4399 28.2052 23.8872 27.2403C25.3346 26.2753 27.2901 26.6665 28.255 28.1138L29.0961 29.3755L34.7596 24.6559C36.096 23.5423 38.082 23.7228 39.1956 25.0592Z" fill="white"/>
+</g>
+<g filter="url(#filter4_dii_4736_13443)">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M44.7656 32.645C44.7656 30.9054 46.1758 29.4953 47.9153 29.4953L67.4131 29.4953C69.1526 29.4953 70.5628 30.9054 70.5628 32.645C70.5628 34.3845 69.1526 35.7946 67.4131 35.7946L47.9153 35.7946C46.1758 35.7946 44.7656 34.3845 44.7656 32.645Z" fill="white"/>
+</g>
+<g filter="url(#filter5_dii_4736_13443)">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M39.1953 52.1426C39.1953 50.4031 40.6055 48.9929 42.345 48.9929L67.4136 48.9929C69.1531 48.9929 70.5633 50.4031 70.5633 52.1426C70.5633 53.8821 69.1531 55.2922 67.4136 55.2922L42.345 55.2922C40.6055 55.2922 39.1953 53.8821 39.1953 52.1426Z" fill="white"/>
+</g>
+<g filter="url(#filter6_dii_4736_13443)">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M25.2656 52.1429C25.2656 50.4034 26.6161 48.9932 28.2819 48.9932L28.5487 48.9932C30.2145 48.9932 31.5649 50.4034 31.5649 52.1429C31.5649 53.8824 30.2145 55.2925 28.5487 55.2925L28.2819 55.2925C26.6161 55.2925 25.2656 53.8824 25.2656 52.1429Z" fill="white"/>
+</g>
+<defs>
+<filter id="filter0_ii_4736_13443" x="0.5" y="5.10139" width="44.7266" height="69.0768" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="-5.24389"/>
+<feGaussianBlur stdDeviation="3.27743"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0.0716667 0 0 0 0 0.136167 0 0 0 0 0.716667 0 0 0 0.35 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow_4736_13443"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="-2.9166"/>
+<feGaussianBlur stdDeviation="2.77077"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0.392157 0 0 0 0 0.796078 0 0 0 0 1 0 0 0 0.65 0"/>
+<feBlend mode="normal" in2="effect1_innerShadow_4736_13443" result="effect2_innerShadow_4736_13443"/>
+</filter>
+<filter id="filter1_dii_4736_13443" x="-2.16288" y="-6.50035" width="97.0836" height="110.732" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="7.86583"/>
+<feGaussianBlur stdDeviation="7.21034"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0.284091 0 0 0 0 1 0 0 0 0.35 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_4736_13443"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_4736_13443" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="-5.24389"/>
+<feGaussianBlur stdDeviation="3.27743"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0.0716667 0 0 0 0 0.136167 0 0 0 0 0.716667 0 0 0 0.35 0"/>
+<feBlend mode="normal" in2="shape" result="effect2_innerShadow_4736_13443"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="-1.96646"/>
+<feGaussianBlur stdDeviation="1.63034"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0.391667 0 0 0 0 0.797222 0 0 0 0 1 0 0 0 0.72 0"/>
+<feBlend mode="normal" in2="effect2_innerShadow_4736_13443" result="effect3_innerShadow_4736_13443"/>
+</filter>
+<filter id="filter2_dii_4736_13443" x="47.5856" y="-5.59912" width="45.3522" height="45.3484" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="6.78428"/>
+<feGaussianBlur stdDeviation="6.21892"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0.0450001 0 0 0 0 0.45 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_4736_13443"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_4736_13443" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="-4.52285"/>
+<feGaussianBlur stdDeviation="2.82678"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0.690196 0 0 0 0 0.776941 0 0 0 0 1 0 0 0 1 0"/>
+<feBlend mode="normal" in2="shape" result="effect2_innerShadow_4736_13443"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="-0.839907"/>
+<feGaussianBlur stdDeviation="1.13071"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.75 0"/>
+<feBlend mode="normal" in2="effect2_innerShadow_4736_13443" result="effect3_innerShadow_4736_13443"/>
+</filter>
+<filter id="filter3_dii_4736_13443" x="10.0465" y="18.2722" width="42.3132" height="38.1386" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="6.78428"/>
+<feGaussianBlur stdDeviation="6.21892"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0.0450001 0 0 0 0 0.45 0 0 0 0.65 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_4736_13443"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_4736_13443" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="-2.51972"/>
+<feGaussianBlur stdDeviation="2.82678"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0.57 0 0 0 0 0.6308 0 0 0 0 0.95 0 0 0 1 0"/>
+<feBlend mode="normal" in2="shape" result="effect2_innerShadow_4736_13443"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="-1.69607"/>
+<feGaussianBlur stdDeviation="1.13071"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.75 0"/>
+<feBlend mode="normal" in2="effect2_innerShadow_4736_13443" result="effect3_innerShadow_4736_13443"/>
+</filter>
+<filter id="filter4_dii_4736_13443" x="32.3278" y="23.8417" width="50.6726" height="31.175" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="6.78428"/>
+<feGaussianBlur stdDeviation="6.21892"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0.0450001 0 0 0 0 0.45 0 0 0 0.65 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_4736_13443"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_4736_13443" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="-2.51972"/>
+<feGaussianBlur stdDeviation="2.82678"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0.57 0 0 0 0 0.6308 0 0 0 0 0.95 0 0 0 1 0"/>
+<feBlend mode="normal" in2="shape" result="effect2_innerShadow_4736_13443"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="-1.69607"/>
+<feGaussianBlur stdDeviation="1.13071"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.75 0"/>
+<feBlend mode="normal" in2="effect2_innerShadow_4736_13443" result="effect3_innerShadow_4736_13443"/>
+</filter>
+<filter id="filter5_dii_4736_13443" x="26.7575" y="43.3394" width="56.2429" height="31.175" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="6.78428"/>
+<feGaussianBlur stdDeviation="6.21892"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0.0450001 0 0 0 0 0.45 0 0 0 0.65 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_4736_13443"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_4736_13443" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="-2.51972"/>
+<feGaussianBlur stdDeviation="2.82678"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0.57 0 0 0 0 0.6308 0 0 0 0 0.95 0 0 0 1 0"/>
+<feBlend mode="normal" in2="shape" result="effect2_innerShadow_4736_13443"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="-1.69607"/>
+<feGaussianBlur stdDeviation="1.13071"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.75 0"/>
+<feBlend mode="normal" in2="effect2_innerShadow_4736_13443" result="effect3_innerShadow_4736_13443"/>
+</filter>
+<filter id="filter6_dii_4736_13443" x="16.8666" y="46.4735" width="23.095" height="24.0024" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="6.78428"/>
+<feGaussianBlur stdDeviation="4.19953"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0.0450001 0 0 0 0 0.45 0 0 0 0.65 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_4736_13443"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_4736_13443" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="-2.51972"/>
+<feGaussianBlur stdDeviation="2.82678"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0.57 0 0 0 0 0.6308 0 0 0 0 0.95 0 0 0 1 0"/>
+<feBlend mode="normal" in2="shape" result="effect2_innerShadow_4736_13443"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="-1.69607"/>
+<feGaussianBlur stdDeviation="1.13071"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.75 0"/>
+<feBlend mode="normal" in2="effect2_innerShadow_4736_13443" result="effect3_innerShadow_4736_13443"/>
+</filter>
+</defs>
+</svg>


### PR DESCRIPTION
## 🐈 PR 요약
> PR 내용 한 줄로 요약
- 관련 테크스펙 링크 : -

## ✨ PR 상세
> PR 상세 내용 개조식으로 작성

- 학부모 일시정지, 선생님 교체기능 main에 먼저 머지하기 위한 cherry pick pr입니다.

## 🚨 참고사항
> 리뷰어들이 알아야 하거나 알면 좋은 참고사항 작성

## 📸 스크린샷
> 화면 캡쳐 이미지

## ✅ 체크리스트
- [ ] Reviewers 태그했나요?
- [ ] Label 지정했나요?
- [ ] 관련 테크스펙 링크 연결했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 보호자용 세션 관리 플로우 추가: 휴회(일시정지) 또는 담당 선생님 변경 선택, 세션 선택 후 제출.
  - 전화번호로 로그인해 본인 수업 목록 확인 및 진행.
  - 제출 완료 화면 제공(안내 문구, 필요 시 외부 신청서 이동 버튼 포함).
  - 화면 상단 뒤로가기 가능한 공통 헤더와 에러 처리 적용.

- 스타일
  - 모바일 뷰포트 정비 및 컨테이너 최대 너비 420px로 확대(보호자/교사 설정).
  - 라디오 서브라벨 가독성 개선, 배지와 세션 카드 UI 추가.
  - 결과 화면 이미지 종류 확장(문서) 및 멀티라인 제목 표시.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->