### PR TITLE
선생님 과외리스트 화면: 과외 건당 분수 표시되도록 변경, 텍스트 수정, 버튼디자인 수정

### DIFF
--- a/app/(route)/(teacher)/teacher/session-review/page.tsx
+++ b/app/(route)/(teacher)/teacher/session-review/page.tsx
@@ -49,9 +49,9 @@ export default function SessionReviewPage() {
           mainClassName="pt-8 w-full px-5"
         >
           <SessionReviewView
-            homework={targetSession!.homework ?? "내용이 없습니다."}
-            understanding={targetSession!.understanding ?? "내용이 없습니다."}
-            classMinute={targetSession!.classMinute ?? 0}
+            homework={targetSession?.homework ?? "내용이 없습니다."}
+            understanding={targetSession?.understanding ?? "내용이 없습니다."}
+            classMinute={targetSession?.classMinute ?? 0}
           />
         </HeaderWithBack>
       </ErrorBoundary>

--- a/app/(route)/(teacher)/teacher/session-review/page.tsx
+++ b/app/(route)/(teacher)/teacher/session-review/page.tsx
@@ -51,6 +51,7 @@ export default function SessionReviewPage() {
           <SessionReviewView
             homework={targetSession!.homework ?? "내용이 없습니다."}
             understanding={targetSession!.understanding ?? "내용이 없습니다."}
+            classMinute={targetSession!.classMinute ?? 0}
           />
         </HeaderWithBack>
       </ErrorBoundary>

--- a/app/(route)/(teacher)/teacher/session-schedule/page.tsx
+++ b/app/(route)/(teacher)/teacher/session-schedule/page.tsx
@@ -9,11 +9,20 @@ import SessionList from "@/components/teacher/SessionList";
 import { useGetSessions } from "@/hooks/query/useGetSessions";
 import TabBar from "@/ui/Bar/TabBar";
 import LoadingUI from "@/ui/LoadingUI";
+import { useGetSessionsMonth } from "@/hooks/query/useGetSessionsMonth";
+import MonthDurationNavigator from "@/components/teacher/Session/MonthDurationNavigator";
 
 export default function TeacherSessionScheduleListPage() {
   const searchParams = useSearchParams();
   const token = searchParams.get("token") ?? "";
+  const classId = searchParams.get("classId");
+
   const { data, isLoading } = useGetSessions(token, 0, 3);
+  const { data: sessionsMonthData } = useGetSessionsMonth(
+    classId
+      ? { classMatchingId: Number(classId), monthCount: 2 }
+      : { token, monthCount: 2 },
+  );
 
   if (isLoading) {
     return <LoadingUI />;
@@ -28,9 +37,17 @@ export default function TeacherSessionScheduleListPage() {
     content: <SessionList key={classId} classId={classId} />,
   }));
 
+  const currentMonth = new Date().getMonth() + 1;
+
   return (
     <ErrorBoundary fallback={<ErrorUI />}>
-      <HeaderWithBack title="과외 일정" className="border-none">
+      <HeaderWithBack title="내 과외 관리" className="border-none">
+        <div className="flex items-center px-5 py-2">
+          <MonthDurationNavigator
+            defaultMonth={currentMonth}
+            monthDuration={sessionsMonthData?.months || {}}
+          />
+        </div>
         <TabBar
           tabs={tabs}
           paramKey="classId"

--- a/app/(route)/(teacher)/teacher/session-schedule/page.tsx
+++ b/app/(route)/(teacher)/teacher/session-schedule/page.tsx
@@ -19,9 +19,11 @@ export default function TeacherSessionScheduleListPage() {
 
   const { data, isLoading } = useGetSessions(token, 0, 3);
   const { data: sessionsMonthData } = useGetSessionsMonth(
-    classId
-      ? { classMatchingId: Number(classId), monthCount: 2 }
-      : { token, monthCount: 2 },
+    token
+      ? { token, monthCount: 2 }
+      : classId
+        ? { classMatchingId: classId, monthCount: 2 }
+        : { token: "", monthCount: 2 },
   );
 
   if (isLoading) {

--- a/app/(route)/(teacher)/teacher/session-schedule/page.tsx
+++ b/app/(route)/(teacher)/teacher/session-schedule/page.tsx
@@ -7,24 +7,17 @@ import ErrorUI from "@/ui/ErrorUI";
 import HeaderWithBack from "@/components/result/HeaderWithBack";
 import SessionList from "@/components/teacher/SessionList";
 import { useGetSessions } from "@/hooks/query/useGetSessions";
+import { useGetSchedules } from "@/hooks/query/useGetSchedules";
 import TabBar from "@/ui/Bar/TabBar";
 import LoadingUI from "@/ui/LoadingUI";
-import { useGetSessionsMonth } from "@/hooks/query/useGetSessionsMonth";
 import MonthDurationNavigator from "@/components/teacher/Session/MonthDurationNavigator";
 
 export default function TeacherSessionScheduleListPage() {
   const searchParams = useSearchParams();
   const token = searchParams.get("token") ?? "";
-  const classId = searchParams.get("classId");
 
   const { data, isLoading } = useGetSessions(token, 0, 3);
-  const { data: sessionsMonthData } = useGetSessionsMonth(
-    token
-      ? { token, monthCount: 2 }
-      : classId
-        ? { classMatchingId: classId, monthCount: 2 }
-        : { token: "", monthCount: 2 },
-  );
+  const { data: schedulesData } = useGetSchedules({ token });
 
   if (isLoading) {
     return <LoadingUI />;
@@ -33,23 +26,34 @@ export default function TeacherSessionScheduleListPage() {
   const classIds = Object.keys(schedules);
   const defaultClassId =
     classIds.find((id) => schedules[id].send === true) ?? classIds[0];
-
-  const tabs = classIds.map((classId) => ({
-    trigger: classId,
-    content: <SessionList key={classId} classId={classId} />,
-  }));
-
   const currentMonth = new Date().getMonth() + 1;
+  const tabs = classIds.map((classId) => {
+    const matchedSchedule = schedulesData?.find(
+      (item) => item.applicationFormId === classId,
+    );
+    const classMatchingId = matchedSchedule?.classMatchingId;
+
+    return {
+      trigger: classId,
+      content: (
+        <div key={classId}>
+          <div className="flex items-center px-5 py-2">
+            {typeof classMatchingId === "number" && (
+              <MonthDurationNavigator
+                classId={classMatchingId}
+                defaultMonth={currentMonth}
+              />
+            )}
+          </div>
+          <SessionList classId={classId} />
+        </div>
+      ),
+    };
+  });
 
   return (
     <ErrorBoundary fallback={<ErrorUI />}>
       <HeaderWithBack title="내 과외 관리" className="border-none">
-        <div className="flex items-center px-5 py-2">
-          <MonthDurationNavigator
-            defaultMonth={currentMonth}
-            monthDuration={sessionsMonthData?.months || {}}
-          />
-        </div>
         <TabBar
           tabs={tabs}
           paramKey="classId"

--- a/app/actions/get-sessions-month/index.ts
+++ b/app/actions/get-sessions-month/index.ts
@@ -8,7 +8,7 @@ export type SessionsMonthParams =
       monthCount: number;
     }
   | {
-      classMatchingId: string;
+      classMatchingId: number;
       token?: never; // classMatchingId가 있을 때는 token 금지
       monthCount: number;
     };

--- a/app/actions/get-sessions-month/index.ts
+++ b/app/actions/get-sessions-month/index.ts
@@ -22,20 +22,15 @@ export interface SessionsMonthResponse {
 export async function getSessionsMonth(params: SessionsMonthParams) {
   const { monthCount } = params;
 
-  // 공통 쿼리 파라미터
-  let query = `monthCount=${monthCount}`;
-
-  if ("token" in params) {
-    query += `&token=${params.token}`;
-  }
-
-  if ("classMatchingId" in params) {
-    query += `&classMatchingId=${params.classMatchingId}`;
-  }
-
-  const res = await httpService.get<SessionsMonthResponse>(
-    `/sessions/month?${query}`,
-  );
+  const res = await httpService.get<SessionsMonthResponse>("/sessions/month", {
+    params: {
+      monthCount,
+      ...(params.token && { token: params.token }),
+      ...(params.classMatchingId && {
+        classMatchingId: params.classMatchingId,
+      }),
+    },
+  });
 
   return res.data;
 }

--- a/app/actions/get-sessions-month/index.ts
+++ b/app/actions/get-sessions-month/index.ts
@@ -1,0 +1,23 @@
+import { httpService } from "@/utils/httpService";
+
+export interface SessionsMonthParams {
+  token: string;
+  classMatchingId: number;
+  monthCount: number; // 몇 개의 월 데이터 가져올 건지 (디폴트: 2)
+}
+
+export interface SessionsMonthResponse {
+  months: {
+    [key: string]: number;
+  };
+}
+
+export async function getSessionsMonth(params: SessionsMonthParams) {
+  const { token, classMatchingId, monthCount } = params;
+
+  const res = await httpService.get<SessionsMonthResponse>(
+    `/sessions/month?token=${token}&classMatchingId=${classMatchingId}&monthCount=${monthCount}`,
+  );
+
+  return res.data;
+}

--- a/app/actions/get-sessions-month/index.ts
+++ b/app/actions/get-sessions-month/index.ts
@@ -1,10 +1,17 @@
 import { httpService } from "@/utils/httpService";
 
-export interface SessionsMonthParams {
-  token: string;
-  classMatchingId: number;
-  monthCount: number; // 몇 개의 월 데이터 가져올 건지 (디폴트: 2)
-}
+// token이나 classMatchingId 둘 중 하나는 있어야 함
+export type SessionsMonthParams =
+  | {
+      token: string;
+      classMatchingId?: never; // token이 있을 때는 classMatchingId 금지
+      monthCount: number;
+    }
+  | {
+      classMatchingId: number;
+      token?: never; // classMatchingId가 있을 때는 token 금지
+      monthCount: number;
+    };
 
 export interface SessionsMonthResponse {
   months: {
@@ -13,10 +20,21 @@ export interface SessionsMonthResponse {
 }
 
 export async function getSessionsMonth(params: SessionsMonthParams) {
-  const { token, classMatchingId, monthCount } = params;
+  const { monthCount } = params;
+
+  // 공통 쿼리 파라미터
+  let query = `monthCount=${monthCount}`;
+
+  if ("token" in params) {
+    query += `&token=${params.token}`;
+  }
+
+  if ("classMatchingId" in params) {
+    query += `&classMatchingId=${params.classMatchingId}`;
+  }
 
   const res = await httpService.get<SessionsMonthResponse>(
-    `/sessions/month?token=${token}&classMatchingId=${classMatchingId}&monthCount=${monthCount}`,
+    `/sessions/month?${query}`,
   );
 
   return res.data;

--- a/app/actions/get-sessions-month/index.ts
+++ b/app/actions/get-sessions-month/index.ts
@@ -8,7 +8,7 @@ export type SessionsMonthParams =
       monthCount: number;
     }
   | {
-      classMatchingId: number;
+      classMatchingId: string;
       token?: never; // classMatchingId가 있을 때는 token 금지
       monthCount: number;
     };

--- a/app/components/teacher/Session/MonthDurationNavigator.tsx
+++ b/app/components/teacher/Session/MonthDurationNavigator.tsx
@@ -1,0 +1,31 @@
+import Image from "next/image";
+
+interface MonthDurationNavigatorProps {
+  defaultMonth: number;
+  monthDuration: {
+    [key: string]: number;
+  };
+}
+
+export default function MonthDurationNavigator(
+  props: MonthDurationNavigatorProps,
+) {
+  const { defaultMonth, monthDuration } = props;
+
+  return (
+    <div className="flex h-12 w-full justify-between bg-grey-100">
+      <Image
+        src="/public/images/icon-arrow.svg"
+        alt="left-arrow"
+        width={40}
+        height={40}
+      />
+      <Image
+        src="/public/images/icon-arrow.svg"
+        alt="right-arrow"
+        width={40}
+        height={40}
+      />
+    </div>
+  );
+}

--- a/app/components/teacher/Session/MonthDurationNavigator.tsx
+++ b/app/components/teacher/Session/MonthDurationNavigator.tsx
@@ -1,4 +1,5 @@
 import Image from "next/image";
+import { useMemo, useState } from "react";
 
 interface MonthDurationNavigatorProps {
   defaultMonth: number;
@@ -12,20 +13,77 @@ export default function MonthDurationNavigator(
 ) {
   const { defaultMonth, monthDuration } = props;
 
+  // monthDuration의 키들을 숫자로 변환하고 정렬
+  const availableMonths = useMemo(() => {
+    return Object.keys(monthDuration)
+      .map(Number)
+      .sort((a, b) => a - b);
+  }, [monthDuration]);
+
+  // 디폴트 월 (defaultMonth 있으면 사용하고, 없으면 그냥 가장 최근 월)
+  const [currentMonth, setCurrentMonth] = useState(() => {
+    if (availableMonths.includes(defaultMonth)) {
+      return defaultMonth;
+    }
+    const maxMonth = Math.max(...availableMonths);
+    return maxMonth;
+  });
+
+  // 현재 월의 인덱스
+  const currentIndex = availableMonths.indexOf(currentMonth);
+
+  // 이전 월로 이동
+  const goToPreviousMonth = () => {
+    if (currentIndex > 0) {
+      setCurrentMonth(availableMonths[currentIndex - 1]);
+    }
+  };
+
+  // 다음 월로 이동
+  const goToNextMonth = () => {
+    if (currentIndex < availableMonths.length - 1) {
+      setCurrentMonth(availableMonths[currentIndex + 1]);
+    }
+  };
+
+  // 화살표 활성화/비활성화 상태
+  const canGoPrevious = currentIndex > 0;
+  const canGoNext = currentIndex < availableMonths.length - 1;
+
+  // 현재 월의 데이터
+  const currentDuration = monthDuration[currentMonth.toString()] || 0;
+
   return (
-    <div className="flex h-12 w-full justify-between bg-grey-100">
-      <Image
-        src="/public/images/icon-arrow.svg"
-        alt="left-arrow"
-        width={40}
-        height={40}
-      />
-      <Image
-        src="/public/images/icon-arrow.svg"
-        alt="right-arrow"
-        width={40}
-        height={40}
-      />
+    <div className="flex h-12 w-full items-center justify-between rounded-xl bg-grey-100 px-5 py-1">
+      <button
+        onClick={goToPreviousMonth}
+        disabled={!canGoPrevious}
+        className={!canGoPrevious ? "opacity-30" : ""}
+      >
+        <Image
+          src="/images/icon_arrow.svg"
+          alt="left-arrow"
+          width={20}
+          height={20}
+        />
+      </button>
+      <div className="flex min-w-36 gap-2 text-[#475569]">
+        <p className="font-semibold">{currentMonth}월 수업진행</p>
+        <p className="font-bold">{currentDuration}분</p>
+      </div>
+      <button
+        onClick={goToNextMonth}
+        disabled={!canGoNext}
+        className={!canGoNext ? "opacity-30" : ""}
+      >
+        <Image
+          src="/images/icon_arrow.svg"
+          alt="right-arrow"
+          width={20}
+          height={20}
+          className="rotate-180"
+        />
+      </button>
     </div>
   );
 }

--- a/app/components/teacher/Session/MonthDurationNavigator.tsx
+++ b/app/components/teacher/Session/MonthDurationNavigator.tsx
@@ -1,57 +1,54 @@
 import Image from "next/image";
 import { useMemo, useState } from "react";
 
+import { useGetSessionsMonth } from "@/hooks/query/useGetSessionsMonth";
+
 interface MonthDurationNavigatorProps {
+  classId: number;
   defaultMonth: number;
-  monthDuration: {
-    [key: string]: number;
-  };
 }
 
-export default function MonthDurationNavigator(
-  props: MonthDurationNavigatorProps,
-) {
-  const { defaultMonth, monthDuration } = props;
+export default function MonthDurationNavigator({
+  classId,
+  defaultMonth,
+}: MonthDurationNavigatorProps) {
+  const { data, isLoading } = useGetSessionsMonth({
+    classMatchingId: classId,
+    monthCount: 2,
+  });
 
-  // monthDuration의 키들을 숫자로 변환하고 정렬
+  const monthDuration = useMemo(() => data?.months ?? {}, [data]);
+
   const availableMonths = useMemo(() => {
     return Object.keys(monthDuration)
       .map(Number)
       .sort((a, b) => a - b);
   }, [monthDuration]);
 
-  // 디폴트 월 (defaultMonth 있으면 사용하고, 없으면 그냥 가장 최근 월)
   const [currentMonth, setCurrentMonth] = useState(() => {
-    if (availableMonths.includes(defaultMonth)) {
-      return defaultMonth;
-    }
-    const maxMonth = Math.max(...availableMonths);
-    return maxMonth;
+    if (availableMonths.includes(defaultMonth)) return defaultMonth;
+    return Math.max(...availableMonths, defaultMonth);
   });
 
-  // 현재 월의 인덱스
   const currentIndex = availableMonths.indexOf(currentMonth);
+  const canGoPrevious = currentIndex > 0;
+  const canGoNext = currentIndex < availableMonths.length - 1;
 
-  // 이전 월로 이동
   const goToPreviousMonth = () => {
-    if (currentIndex > 0) {
+    if (canGoPrevious) {
       setCurrentMonth(availableMonths[currentIndex - 1]);
     }
   };
 
-  // 다음 월로 이동
   const goToNextMonth = () => {
-    if (currentIndex < availableMonths.length - 1) {
+    if (canGoNext) {
       setCurrentMonth(availableMonths[currentIndex + 1]);
     }
   };
 
-  // 화살표 활성화/비활성화 상태
-  const canGoPrevious = currentIndex > 0;
-  const canGoNext = currentIndex < availableMonths.length - 1;
+  const currentDuration = monthDuration[currentMonth.toString()] ?? 0;
 
-  // 현재 월의 데이터
-  const currentDuration = monthDuration[currentMonth.toString()] || 0;
+  if (isLoading) return null;
 
   return (
     <div className="flex h-12 w-full items-center justify-between rounded-xl bg-grey-100 px-5 py-1">

--- a/app/components/teacher/Session/MonthDurationNavigator.tsx
+++ b/app/components/teacher/Session/MonthDurationNavigator.tsx
@@ -67,7 +67,7 @@ export default function MonthDurationNavigator(
           height={20}
         />
       </button>
-      <div className="flex min-w-36 gap-2 text-[#475569]">
+      <div className="flex min-w-36 items-center justify-center gap-2 text-[#475569]">
         <p className="font-semibold">{currentMonth}월 수업진행</p>
         <p className="font-bold">{currentDuration}분</p>
       </div>

--- a/app/components/teacher/Session/SessionReviewView.tsx
+++ b/app/components/teacher/Session/SessionReviewView.tsx
@@ -7,11 +7,13 @@ import Radio from "@/ui/Radio";
 interface SessionReviewViewProps {
   homework: string;
   understanding: string;
+  classMinute: number;
 }
 
 export default function SessionReviewView({
   homework,
   understanding,
+  classMinute,
 }: SessionReviewViewProps) {
   const selectedItem = HOMEWORK_PROGRESS_LIST.find(
     (item) => item.label === homework,
@@ -19,9 +21,16 @@ export default function SessionReviewView({
 
   return (
     <div className="flex w-full flex-col">
+      <DivWithLabel label="수업 시간" className="mb-4">
+        <p className="whitespace-pre-wrap text-[16px] leading-6 text-gray-700">
+          {classMinute}분
+        </p>
+      </DivWithLabel>
+      {/* divider */}
+      <div className="-mx-5 border-t-8 border-gray-100" />
       <DivWithLabel
         label="아이가 숙제를 모두 완료했나요?"
-        className="mb-4 w-full"
+        className="mb-4 mt-5 w-full"
       >
         {selectedItem && (
           <div className="py-4">

--- a/app/components/teacher/SessionList/index.tsx
+++ b/app/components/teacher/SessionList/index.tsx
@@ -72,18 +72,20 @@ export default function SessionList({ classId }: SessionListProps) {
             chipText="미완료"
             isSelected={!isComplete}
             onClick={() => changeFilter(false)}
+            className="shadow-md"
           />
           <Chip
             chipText="완료"
             isSelected={isComplete}
             onClick={() => changeFilter(true)}
+            className="shadow-md"
           />
         </div>
         <Button
           leftIcon={
-            <Image src={Calender} width={20} height={20} alt="calender" />
+            <Image src={Calender} width={16} height={16} alt="calender" />
           }
-          className="text-grey-700 w-fit cursor-pointer justify-normal gap-1 bg-transparent px-3 py-[6px] text-sm"
+          className="flex !w-fit items-center gap-1 !whitespace-pre-wrap rounded-full border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-md hover:bg-gray-50"
           onClick={() => {
             params.set("classId", classId);
             router.push(`/teacher/session-change?${params.toString()}`);

--- a/app/components/teacher/SessionList/index.tsx
+++ b/app/components/teacher/SessionList/index.tsx
@@ -102,6 +102,7 @@ export default function SessionList({ classId }: SessionListProps) {
             key={session.id}
             date={session.date}
             time={session.time}
+            classMinute={session.classMinute}
             statusLabel={session.statusLabel}
             actions={session.actions}
             showMoneyReminder={session.showMoneyReminder}

--- a/app/components/teacher/SessionList/useSessionList.ts
+++ b/app/components/teacher/SessionList/useSessionList.ts
@@ -18,6 +18,7 @@ export interface SessionItem {
   actions: ActionButton[];
   showMoneyReminder: boolean;
   complete: boolean;
+  classMinute: number;
 }
 
 export function useSessionList(data: SessionResponse[]): SessionItem[] {
@@ -32,6 +33,7 @@ export function useSessionList(data: SessionResponse[]): SessionItem[] {
         complete,
         classDate,
         classStart,
+        classMinute,
       } = session;
 
       // Date 객체 생성 및 시간 포맷
@@ -82,6 +84,7 @@ export function useSessionList(data: SessionResponse[]): SessionItem[] {
         actions,
         showMoneyReminder,
         complete,
+        classMinute,
       };
     });
 

--- a/app/hooks/mutation/usePatchSessions.ts
+++ b/app/hooks/mutation/usePatchSessions.ts
@@ -101,6 +101,9 @@ export function useSessionMutations() {
 
       await queryClient.refetchQueries({ queryKey: ["sessions"] });
 
+      // sessions-month 쿼리도 무효화
+      await queryClient.invalidateQueries({ queryKey: ["sessions-month"] });
+
       params.set("is-complete", "true");
       router.push(`/teacher/session-schedule?${params.toString()}`);
 

--- a/app/hooks/query/useGetSessionsMonth.ts
+++ b/app/hooks/query/useGetSessionsMonth.ts
@@ -1,0 +1,16 @@
+import { useQuery } from "@tanstack/react-query";
+
+import {
+  getSessionsMonth,
+  SessionsMonthParams,
+} from "@/actions/get-sessions-month";
+
+export function useGetSessionsMonth(params: SessionsMonthParams) {
+  return useQuery({
+    queryKey: ["sessions-month", params],
+    queryFn: async () => {
+      const res = await getSessionsMonth(params);
+      return res;
+    },
+  });
+}

--- a/app/hooks/query/useGetSessionsMonth.ts
+++ b/app/hooks/query/useGetSessionsMonth.ts
@@ -12,5 +12,6 @@ export function useGetSessionsMonth(params: SessionsMonthParams) {
       const res = await getSessionsMonth(params);
       return res;
     },
+    enabled: !!params.token || !!params.classMatchingId,
   });
 }

--- a/app/ui/Card/SessionListCard/index.tsx
+++ b/app/ui/Card/SessionListCard/index.tsx
@@ -23,6 +23,7 @@ export interface SessionListCardProps {
   classSessionId: number;
   date: Date;
   time: string;
+  classMinute: number;
   statusLabel: string;
   actions: ActionButton[];
   showMoneyReminder?: boolean;
@@ -34,6 +35,7 @@ export default function SessionListCard({
   classSessionId,
   date,
   time,
+  classMinute,
   statusLabel,
   actions,
   showMoneyReminder,
@@ -101,13 +103,12 @@ export default function SessionListCard({
             </span>
           )}
           <span className="text-[16px] font-[600] text-gray-900">
-            {`${date.getMonth() + 1}.${date.getDate()} ${date.toLocaleDateString(
+            {`${date.getMonth() + 1}.${date.getDate()} (${date.toLocaleDateString(
               "ko-KR",
-              {
-                weekday: "long",
-              },
-            )} ${time}`}
+              { weekday: "short" },
+            )}) ${time}`}
           </span>
+          <span className="ml-[6px] text-gray-500">{`${classMinute}분`}</span>
         </div>
         <IconDown
           className={cn({

--- a/public/images/icon_arrow.svg
+++ b/public/images/icon_arrow.svg
@@ -1,0 +1,3 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M12.0859 5L7.08594 10L12.0859 15" stroke="#475569" stroke-width="1.66667" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>


### PR DESCRIPTION
## 🐈 PR 요약
> PR 내용 한 줄로 요약
- 관련 테크스펙 링크 : -

## ✨ PR 상세
> PR 상세 내용 개조식으로 작성

- 과외 건당 분수 표시되도록 변경
- 정규일정 변경, 칩 버튼 디자인 수정
- 자잘한 텍스트 수정

## 🚨 참고사항
> 리뷰어들이 알아야 하거나 알면 좋은 참고사항 작성

- develop에 머지되어있던 커밋들을 최대한 살리기위해 cherry-pick으로 가져온 후
- 기존 혜원님이 develop에 작성해주셨던 monthDurationNavigator 를 조금 수정했습니다.
- [Commits on Sep 25, 2025] 이날의 커밋 사항만 확인해주시면됩니다!

- 기존에는 string으로 받았던 classMatchingId를 number로 변경했습니다.
- /sessions 에는 classMatchingId 데이터가 없어서
classMatchingId 는 /schedules?token=${token} 엔드포인트에서 가져오도록 했습니다.

## 📸 스크린샷
> 화면 캡쳐 이미지

https://github.com/user-attachments/assets/398e9ad2-dc68-4eff-a95b-a2952202ce92

## ✅ 체크리스트
- [x] Reviewers 태그했나요?
- [x] Label 지정했나요?
- [ ] 관련 테크스펙 링크 연결했나요?
