### PR TITLE
휴강 카드일때 수업 분수 표시 제거

### DIFF
--- a/app/ui/Card/SessionListCard/index.tsx
+++ b/app/ui/Card/SessionListCard/index.tsx
@@ -108,7 +108,9 @@ export default function SessionListCard({
               { weekday: "short" },
             )}) ${time}`}
           </span>
-          <span className="ml-[6px] text-gray-500">{`${classMinute}분`}</span>
+          {statusLabel !== "휴강" && (
+            <span className="ml-[6px] text-gray-500">{`${classMinute}분`}</span>
+          )}
         </div>
         <IconDown
           className={cn({


### PR DESCRIPTION
## 🐈 PR 요약
> PR 내용 한 줄로 요약
- 관련 테크스펙 링크 :  - 

## ✨ PR 상세
> PR 상세 내용 개조식으로 작성

- 휴강 카드일때 수업 분수 표시 제거

## 🚨 참고사항
> 리뷰어들이 알아야 하거나 알면 좋은 참고사항 작성

- 현재 당일휴강 플로우가 없기 때문에, 휴강 카드일때는 수업분수 제거하도록 했습니다.
- 당일휴강이 추가 개발되면, 선생님,학부모 당일휴강에 따라 처리하도록 변경하겠습니다.

## 📸 스크린샷
> 화면 캡쳐 이미지
<img width="398" height="253" alt="스크린샷 2025-09-28 오후 2 33 48" src="https://github.com/user-attachments/assets/24a949d6-e322-473f-91f9-562a24396e90" />
<img width="399" height="279" alt="스크린샷 2025-09-28 오후 2 33 55" src="https://github.com/user-attachments/assets/d582b19f-a892-43dc-bd50-2c33e87e8f16" />



## ✅ 체크리스트
- [x] Reviewers 태그했나요?
- [x] Label 지정했나요?
- [ ] 관련 테크스펙 링크 연결했나요?
