### PR TITLE
[feat] 선생님 수업관리 페이지 로그인 구현

### DIFF
--- a/app/(route)/(teacher)/teacher/session-schedule/login/page.tsx
+++ b/app/(route)/(teacher)/teacher/session-schedule/login/page.tsx
@@ -1,0 +1,5 @@
+import TeacherSessionLogin from "@/components/teacher/Session/TeacherSessionLogin";
+
+export default function TeacherSessionScheduleLoginPage() {
+  return <TeacherSessionLogin />;
+}

--- a/app/actions/post-token-sessions/index.ts
+++ b/app/actions/post-token-sessions/index.ts
@@ -1,0 +1,22 @@
+import { httpService } from "@/utils/httpService";
+
+export interface TeacherSessionScheduleLoginParams {
+  name: string;
+  phoneNumber: string;
+}
+
+export interface TeacherSessionScheduleLoginResponse {
+  token: string;
+}
+
+export async function postTokenSessions(
+  params: TeacherSessionScheduleLoginParams,
+): Promise<TeacherSessionScheduleLoginResponse> {
+  const { name, phoneNumber } = params;
+  const res = await httpService.post<TeacherSessionScheduleLoginResponse>(
+    `/token/sessions?${new URLSearchParams({ name, phoneNumber }).toString()}`,
+    {}, // 빈 body
+  );
+
+  return res.data;
+}

--- a/app/components/teacher/Session/TeacherSessionLogin.tsx
+++ b/app/components/teacher/Session/TeacherSessionLogin.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import { usePostTokenSessions } from "@/hooks/mutation/usePostTokenSessions";
 import { useGlobalSnackbar } from "@/providers/GlobalSnackBar";
@@ -15,7 +15,7 @@ export default function TeacherSessionLogin() {
 
   const { mutate: postTokenSessions } = usePostTokenSessions();
 
-  const handleLogin = () => {
+  const handleLogin = useCallback(() => {
     setIsLoading(true);
     postTokenSessions(
       { name, phoneNumber },
@@ -26,6 +26,9 @@ export default function TeacherSessionLogin() {
               "조회된 수업 정보가 없습니다. 관리자에게 문의해 주세요.",
             );
           } else {
+            // 성공
+            localStorage.setItem("name", name);
+            localStorage.setItem("phoneNumber", phoneNumber);
             router.push(`/teacher/session-schedule?token=${data.token}`);
           }
           setIsLoading(false);
@@ -36,7 +39,17 @@ export default function TeacherSessionLogin() {
         },
       },
     );
-  };
+  }, [name, phoneNumber, postTokenSessions, toast, router]);
+
+  useEffect(() => {
+    const name = localStorage.getItem("name");
+    const phoneNumber = localStorage.getItem("phoneNumber");
+    if (name && phoneNumber) {
+      setName(name);
+      setPhoneNumber(phoneNumber);
+      handleLogin();
+    }
+  }, [router, handleLogin]);
 
   return (
     <div>

--- a/app/components/teacher/Session/TeacherSessionLogin.tsx
+++ b/app/components/teacher/Session/TeacherSessionLogin.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+import { usePostTokenSessions } from "@/hooks/mutation/usePostTokenSessions";
+import { useGlobalSnackbar } from "@/providers/GlobalSnackBar";
+
+export default function TeacherSessionLogin() {
+  const toast = useGlobalSnackbar();
+  const router = useRouter();
+  const [name, setName] = useState("");
+  const [phoneNumber, setPhoneNumber] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+
+  const { mutate: postTokenSessions } = usePostTokenSessions();
+
+  const handleLogin = () => {
+    setIsLoading(true);
+    postTokenSessions(
+      { name, phoneNumber },
+      {
+        onSuccess: (data) => {
+          if (!data.token) {
+            toast.warning(
+              "조회된 수업 정보가 없습니다. 관리자에게 문의해 주세요.",
+            );
+          } else {
+            router.push(`/teacher/session-schedule?token=${data.token}`);
+          }
+          setIsLoading(false);
+        },
+        onError: () => {
+          toast.warning("이름 또는 전화번호 정보가 일치하지 않습니다.");
+          setIsLoading(false);
+        },
+      },
+    );
+  };
+
+  return (
+    <div>
+      <p className="pb-5 pt-10 text-center font-pretendard text-xl font-bold text-labelStrong">
+        <span className="text-primary">Y-Edu</span> 선생님 수업 관리
+      </p>
+      <div className="flex flex-col px-5">
+        <section>
+          <p className="mb-6 text-center text-sm text-gray-600">
+            선생님 등록 시 입력한 이름과 전화번호를 입력하면
+            <br />
+            본인의 수업 관리 페이지로 이동할 수 있습니다.
+          </p>
+        </section>
+        <input
+          type="text"
+          placeholder="이름 (ex.김에듀)"
+          className="input mb-5 mt-10 h-[48px] w-full rounded-[12px] border py-3 pl-5"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+        />
+        <input
+          type="tel"
+          placeholder="전화번호 (ex.01012345678)"
+          className="input mb-10 h-[48px] w-full rounded-[12px] border py-3 pl-5"
+          value={phoneNumber}
+          onChange={(e) => setPhoneNumber(e.target.value)}
+        />
+        <button
+          onClick={handleLogin}
+          disabled={isLoading}
+          className="relative flex h-[48px] w-full items-center justify-center rounded-[12px] bg-primaryNormal text-white"
+        >
+          {isLoading ? (
+            <span className="loader size-6 rounded-full border-4 border-t-transparent" />
+          ) : (
+            "수업 관리 페이지로 이동"
+          )}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/app/hooks/mutation/usePostTokenSessions.ts
+++ b/app/hooks/mutation/usePostTokenSessions.ts
@@ -1,0 +1,9 @@
+import { useMutation } from "@tanstack/react-query";
+
+import { postTokenSessions } from "@/actions/post-token-sessions";
+
+export function usePostTokenSessions() {
+  return useMutation({
+    mutationFn: postTokenSessions,
+  });
+}


### PR DESCRIPTION
## 🐈 PR 요약
> PR 내용 한 줄로 요약
- 관련 테크스펙 링크 : x
- 선생님 수업관리 페이지 이름, 전화번호 로그인

## ✨ PR 상세
> PR 상세 내용 개조식으로 작성
- 선생님 수업관리 페이지 이름, 전화번호 로그인 구현
- 로그인 성공하면 수업관리 페이지로 이동
- 한번 로그인 성공하면 이름, 전화번호 localStorage에 저장 -> 후에 다시 접근했을 때 자동 로그인
- 실패하면 toast 띄우고 이동 X

## 🚨 참고사항
> 리뷰어들이 알아야 하거나 알면 좋은 참고사항 작성

## 📸 스크린샷
> 화면 캡쳐 이미지

<img width="371" height="625" alt="image" src="https://github.com/user-attachments/assets/02a24b88-c9f9-4731-9b2f-2844d1b3b3ac" />


## ✅ 체크리스트
- [x] Reviewers 태그했나요?
- [x] Label 지정했나요?
- [ ] 관련 테크스펙 링크 연결했나요?
