### PR TITLE
[fix] 과외 완료 안 되는 버그 픽스

### DIFF
--- a/app/(route)/(teacher)/teacher/session-complete/page.tsx
+++ b/app/(route)/(teacher)/teacher/session-complete/page.tsx
@@ -27,7 +27,11 @@ export default function SessionCompletePage() {
   const token = searchParams.get("token") ?? "";
   const classSessionId = searchParams.get("sessionId");
 
-  const { data: sessions } = useGetSessions(token, 0, 30);
+  const { data: sessions, isLoading: isSessionsLoading } = useGetSessions(
+    token,
+    0,
+    30,
+  );
   const { data, isLoading } = useGetSchedules({ token });
   const { data: sessionByToken } = useGetSessionByToken({ token: token ?? "" });
 
@@ -42,24 +46,30 @@ export default function SessionCompletePage() {
     : null;
 
   const activeSessionData = useMemo(() => {
-    if (sessionFromCache) {
-      return {
-        isComplete: sessionFromCache.complete,
-        classTime: {
-          start: sessionFromCache.classStart,
-          classMinute: sessionFromCache.classMinute,
-        },
-        sessionDate: sessionFromCache.classDate,
-        teacherId: sessionByToken?.teacherId,
-      };
+    // sessionId가 있는 경우: sessionFromCache만 사용 (sessionByToken은 임의의 세션 반환)
+    if (classSessionId) {
+      if (sessionFromCache) {
+        return {
+          isComplete: sessionFromCache.complete,
+          classTime: {
+            start: sessionFromCache.classStart,
+            classMinute: sessionFromCache.classMinute,
+          },
+          sessionDate: sessionFromCache.classDate,
+          teacherId: sessionByToken?.teacherId,
+        };
+      }
+      // sessionFromCache가 아직 로딩 중이면 null 반환 (잘못된 sessionByToken 사용 방지)
+      return null;
     }
 
+    // sessionId가 없는 경우에만 sessionByToken 사용
     if (sessionByToken?.sessionDate) {
       return sessionByToken;
     }
 
     return null;
-  }, [sessionFromCache, sessionByToken]);
+  }, [sessionFromCache, sessionByToken, classSessionId]);
 
   const isEmpty = !activeSessionData;
 
@@ -110,7 +120,7 @@ export default function SessionCompletePage() {
     }
   }, [activeSessionData]);
 
-  if (isLoading) {
+  if (isLoading || (classSessionId && isSessionsLoading)) {
     return <LoadingUI />;
   }
 


### PR DESCRIPTION
## 🐈 PR 요약
> PR 내용 한 줄로 요약
- 관련 테크스펙 링크 : x
- 로그인 후, 과외 완료 안 되는 문제 수정

## ✨ PR 상세
> PR 상세 내용 개조식으로 작성
- 버그: 이름&전화번호 로그인 후, 최초 1회의 과외 완료 시도할 때 "이미 리뷰 작성을 완료한 수업입니다" 오류
- 로그인 후에 받는 토큰은 임의의 세션에서 반환받는 토큰 (아마 토큰만 반환해주고 완료 처리 해버리는듯??)
  - 그래서 이미 완료된 수업이라고 나오는 것
  - 최초 1번만 그 오류가 일어나고, 그 이후에는 `sessionFromCache` 데이터가 있으니까 정상 동작함
-> `sessionId`가 있으면 `sessionFromCache` 사용하고, 없을 때만 `sessionByToken` 사용하게 변경

## 🚨 참고사항
> 리뷰어들이 알아야 하거나 알면 좋은 참고사항 작성

## 📸 스크린샷
> 화면 캡쳐 이미지

## ✅ 체크리스트
- [ ] Reviewers 태그했나요?
- [ ] Label 지정했나요?
- [ ] 관련 테크스펙 링크 연결했나요?
